### PR TITLE
Fix invalid Tabler icon on control panel design page

### DIFF
--- a/src/pages/services/control-panel-design.astro
+++ b/src/pages/services/control-panel-design.astro
@@ -122,7 +122,7 @@ const metadata = {
         title: 'Step 4: <span class="font-medium">Fabrication Support</span>',
         description:
           'Provide clarification, field change tracking, and as-built updates through installation and commissioning.',
-        icon: 'tabler:toolbox',
+        icon: 'tabler:wrench',
       },
     ]}
     image={{


### PR DESCRIPTION
## Summary
- replace the non-existent `tabler:toolbox` icon with the available `tabler:wrench` icon on the control panel design service page

## Testing
- npm run build *(fails: remote image fetch attempt in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87daea4f48332be084913d2522014