### PR TITLE
Remove services dropdown from header navigation

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -13,28 +13,6 @@ export const headerData = {
     {
       text: 'Services',
       href: getPermalink('/services'),
-      links: [
-        {
-          text: 'PLC Programming & Industrial Control',
-          href: getPermalink('/services/plc-programming'),
-        },
-        {
-          text: 'HMI & SCADA Development',
-          href: getPermalink('/services/hmi-scada'),
-        },
-        {
-          text: 'Web HMI & Remote Dashboards',
-          href: getPermalink('/services/web-hmi'),
-        },
-        {
-          text: 'IIoT & Cloud Integration',
-          href: getPermalink('/services/iiot-cloud'),
-        },
-        {
-          text: 'Control Panel & Electrical Design',
-          href: getPermalink('/services/control-panel-design'),
-        },
-      ],
     },
     {
       text: 'Portfolio',


### PR DESCRIPTION
## Summary
- remove the nested Services submenu so the header renders it as a direct link

## Testing
- npm run check:eslint

------
https://chatgpt.com/codex/tasks/task_e_68c9d1057e588332802fc5041123fca1