### PR TITLE
Complete Spanish translations across demos and blog

### DIFF
--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -10,12 +10,15 @@ import type { Post } from '~/types';
 import { getPermalink } from '~/utils/permalinks';
 import { findImage } from '~/utils/images';
 import { getFormattedDate } from '~/utils/utils';
+import { translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export interface Props {
   post: Post;
 }
 
 const { post } = Astro.props;
+const currentLang: Lang = (post.lang ?? defaultLang) as Lang;
 const image = (await findImage(post.image)) as ImageMetadata | undefined;
 
 const link = APP_BLOG?.post?.isEnabled ? getPermalink(post.permalink, 'post') : '';
@@ -82,7 +85,10 @@ const link = APP_BLOG?.post?.isEnabled ? getPermalink(post.permalink, 'post') : 
               <>
                 {' '}
                 ·{' '}
-                <a class="hover:underline" href={getPermalink(post.category.slug, 'category')}>
+                <a
+                  class="hover:underline"
+                  href={translatePath(getPermalink(post.category.slug, 'category'), currentLang)}
+                >
                   {post.category.title}
                 </a>
               </>
@@ -110,7 +116,7 @@ const link = APP_BLOG?.post?.isEnabled ? getPermalink(post.permalink, 'post') : 
     {
       post.tags && Array.isArray(post.tags) ? (
         <footer class="mt-5">
-          <PostTags tags={post.tags} />
+          <PostTags tags={post.tags} lang={currentLang} />
         </footer>
       ) : (
         <Fragment />

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -5,6 +5,8 @@ import { getRelatedPosts } from '~/utils/blog';
 import BlogHighlightedPosts from '../widgets/BlogHighlightedPosts.astro';
 import type { Post } from '~/types';
 import { getBlogPermalink } from '~/utils/permalinks';
+import { translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export interface Props {
   post: Post;
@@ -13,6 +15,8 @@ export interface Props {
 const { post } = Astro.props;
 
 const relatedPosts = post.tags ? await getRelatedPosts(post, 4) : [];
+const postLang: Lang = (post.lang ?? defaultLang) as Lang;
+const blogLink = translatePath(getBlogPermalink(), postLang);
 ---
 
 {
@@ -24,7 +28,7 @@ const relatedPosts = post.tags ? await getRelatedPosts(post, 4) : [];
       }}
       title="Related Posts"
       linkText="View All Posts"
-      linkUrl={getBlogPermalink()}
+      linkUrl={blogLink}
       postIds={relatedPosts.map((post) => post.id)}
     />
   ) : null

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -9,6 +9,8 @@ import { getPermalink } from '~/utils/permalinks';
 import { getFormattedDate } from '~/utils/utils';
 
 import type { Post } from '~/types';
+import { translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export interface Props {
   post: Post;
@@ -16,6 +18,10 @@ export interface Props {
 }
 
 const { post, url } = Astro.props;
+const currentLang: Lang = (post.lang ?? defaultLang) as Lang;
+
+const readingLabel =
+  currentLang === 'es' ? 'min de lectura' : currentLang === 'pt' ? 'min de leitura' : 'min read';
 ---
 
 <section class="py-8 sm:py-16 lg:py-20 mx-auto">
@@ -43,7 +49,10 @@ const { post, url } = Astro.props;
               <>
                 {' '}
                 ·{' '}
-                <a class="hover:underline inline-block" href={getPermalink(post.category.slug, 'category')}>
+                <a
+                  class="hover:underline inline-block"
+                  href={translatePath(getPermalink(post.category.slug, 'category'), currentLang)}
+                >
                   {post.category.title}
                 </a>
               </>
@@ -52,7 +61,7 @@ const { post, url } = Astro.props;
           {
             post.readingTime && (
               <>
-                &nbsp;· <span>{post.readingTime}</span> min read
+                &nbsp;· <span>{post.readingTime}</span> {readingLabel}
               </>
             )
           }
@@ -96,7 +105,7 @@ const { post, url } = Astro.props;
       <slot />
     </div>
     <div class="mx-auto px-6 sm:px-6 max-w-3xl mt-8 flex justify-between flex-col sm:flex-row">
-      <PostTags tags={post.tags} class="mr-5 rtl:mr-0 rtl:ml-5" />
+      <PostTags tags={post.tags} class="mr-5 rtl:mr-0 rtl:ml-5" lang={currentLang} />
       <SocialShare url={url} text={post.title} class="mt-5 sm:mt-1 align-middle text-gray-500 dark:text-slate-600" />
     </div>
   </article>

--- a/src/components/blog/Tags.astro
+++ b/src/components/blog/Tags.astro
@@ -1,5 +1,7 @@
 ---
 import { getPermalink } from '~/utils/permalinks';
+import { translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 import { APP_BLOG } from 'astrowind:config';
 import type { Post } from '~/types';
@@ -9,9 +11,11 @@ export interface Props {
   class?: string;
   title?: string | undefined;
   isCategory?: boolean;
+  lang?: Lang;
 }
 
-const { tags, class: className = 'text-sm', title = undefined, isCategory = false } = Astro.props;
+const { tags, class: className = 'text-sm', title = undefined, isCategory = false, lang: providedLang } = Astro.props;
+const currentLang: Lang = (providedLang ?? defaultLang) as Lang;
 ---
 
 {
@@ -29,7 +33,7 @@ const { tags, class: className = 'text-sm', title = undefined, isCategory = fals
               tag.title
             ) : (
               <a
-                href={getPermalink(tag.slug, isCategory ? 'category' : 'tag')}
+                href={translatePath(getPermalink(tag.slug, isCategory ? 'category' : 'tag'), currentLang)}
                 class="text-muted dark:text-slate-300 hover:text-primary dark:hover:text-gray-200"
               >
                 {tag.title}

--- a/src/components/blog/ToBlogLink.astro
+++ b/src/components/blog/ToBlogLink.astro
@@ -3,18 +3,24 @@ import { Icon } from 'astro-icon/components';
 import { getBlogPermalink } from '~/utils/permalinks';
 import { I18N } from 'astrowind:config';
 import Button from '~/components/ui/Button.astro';
+import { getLangFromUrl, translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 const { textDirection } = I18N;
+const url = Astro.url;
+const currentLang: Lang = url ? (getLangFromUrl(url) as Lang) : defaultLang;
+const link = translatePath(getBlogPermalink(), currentLang);
+const label = currentLang === 'es' ? 'Volver al blog' : currentLang === 'pt' ? 'Voltar ao blog' : 'Back to Blog';
 ---
 
 <div class="mx-auto px-6 sm:px-6 max-w-3xl pt-8 md:pt-4 pb-12 md:pb-20">
-  <Button variant="tertiary" class="px-3 md:px-3" href={getBlogPermalink()}>
+  <Button variant="tertiary" class="px-3 md:px-3" href={link}>
     {
       textDirection === 'rtl' ? (
         <Icon name="tabler:chevron-right" class="w-5 h-5 mr-1 -ml-1.5 rtl:-mr-1.5 rtl:ml-1" />
       ) : (
         <Icon name="tabler:chevron-left" class="w-5 h-5 mr-1 -ml-1.5 rtl:-mr-1.5 rtl:ml-1" />
       )
-    } Back to Blog
+    } {label}
   </Button>
 </div>

--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -1,6 +1,9 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { getLangFromUrl, translatePath } from '~/i18n/utils';
+import { t, type Lang } from '~/i18n/ui';
 import { footerData } from '~/navigation';
+import { getPermalink } from '~/utils/permalinks';
 
 interface Link {
   text?: string;
@@ -14,7 +17,13 @@ export interface Props {
   socialLinks?: Array<Link>;
 }
 
-const { socialLinks = footerData.socialLinks } = Astro.props;
+const url = Astro.url;
+const fallbackSocialLinks = footerData(url).socialLinks;
+const { socialLinks = fallbackSocialLinks } = Astro.props;
+const lang = url ? (getLangFromUrl(url) as Lang) : ('en' as Lang);
+const contactHref = translatePath(getPermalink('/contact'), lang);
+const badgeText = t(lang, 'announcement_badge');
+const messageText = t(lang, 'announcement_message');
 ---
 
 <div
@@ -23,11 +32,9 @@ const { socialLinks = footerData.socialLinks } = Astro.props;
   <div class="flex-1 flex items-center">
     <span
       class="dark:bg-slate-700 bg-white/40 dark:text-slate-300 font-semibold px-1 py-0.5 text-xs mr-0.5 rtl:mr-0 rtl:ml-0.5 inline-block"
-      >Free</span
+      >{badgeText}</span
     >
-    <a href="/contact" class="text-muted hover:underline dark:text-slate-400 font-medium"
-      >Unlock your 1‑hour consultancy—schedule your session today! »</a
-    >
+    <a href={contactHref} class="text-muted hover:underline dark:text-slate-400 font-medium">{messageText}</a>
   </div>
   
   {

--- a/src/components/widgets/BlogHighlightedPosts.astro
+++ b/src/components/widgets/BlogHighlightedPosts.astro
@@ -7,6 +7,8 @@ import { getBlogPermalink } from '~/utils/permalinks';
 import { findPostsByIds } from '~/utils/blog';
 import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import type { Widget } from '~/types';
+import { getLangFromUrl, translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export interface Props extends Widget {
   title?: string;
@@ -29,7 +31,11 @@ const {
   bg = await Astro.slots.render('bg'),
 } = Astro.props;
 
-const posts = APP_BLOG.isEnabled ? await findPostsByIds(postIds) : [];
+const url = Astro.url;
+const currentLang: Lang = url ? (getLangFromUrl(url) as Lang) : defaultLang;
+const posts = APP_BLOG.isEnabled ? await findPostsByIds(postIds, currentLang) : [];
+const resolvedLinkUrl =
+  typeof linkUrl === 'string' ? translatePath(linkUrl, currentLang) : (linkUrl as string | URL | undefined);
 ---
 
 {
@@ -42,10 +48,10 @@ const posts = APP_BLOG.isEnabled ? await findPostsByIds(postIds) : [];
               class="text-3xl font-bold tracking-tight sm:text-4xl sm:leading-none group font-heading mb-2"
               set:html={title}
             />
-            {APP_BLOG.list.isEnabled && linkText && linkUrl && (
+            {APP_BLOG.list.isEnabled && linkText && resolvedLinkUrl && (
               <a
                 class="text-muted dark:text-slate-400 hover:text-primary transition ease-in duration-200 block mb-6 lg:mb-0"
-                href={linkUrl}
+                href={resolvedLinkUrl}
               >
                 {linkText} »
               </a>

--- a/src/components/widgets/BlogLatestPosts.astro
+++ b/src/components/widgets/BlogLatestPosts.astro
@@ -8,6 +8,8 @@ import { findLatestPosts } from '~/utils/blog';
 import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import type { Widget } from '~/types';
 import Button from '../ui/Button.astro';
+import { getLangFromUrl, translatePath } from '~/i18n/utils';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export interface Props extends Widget {
   title?: string;
@@ -30,7 +32,11 @@ const {
   bg = await Astro.slots.render('bg'),
 } = Astro.props;
 
-const posts = APP_BLOG.isEnabled ? await findLatestPosts({ count }) : [];
+const url = Astro.url;
+const currentLang: Lang = url ? (getLangFromUrl(url) as Lang) : defaultLang;
+const posts = APP_BLOG.isEnabled ? await findLatestPosts({ count, lang: currentLang }) : [];
+const resolvedLinkUrl =
+  typeof linkUrl === 'string' ? translatePath(linkUrl, currentLang) : (linkUrl as string | URL | undefined);
 ---
 
 {
@@ -43,8 +49,8 @@ const posts = APP_BLOG.isEnabled ? await findLatestPosts({ count }) : [];
               class="text-3xl font-bold tracking-tight sm:text-4xl sm:leading-none group font-heading mb-2"
               set:html={title}
             />
-            {APP_BLOG.list.isEnabled && linkText && linkUrl && (
-              <Button variant="link" href={linkUrl}>
+            {APP_BLOG.list.isEnabled && linkText && resolvedLinkUrl && (
+              <Button variant="link" href={resolvedLinkUrl}>
                 {' '}
                 {linkText} »
               </Button>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -52,6 +52,9 @@ const postCollection = defineCollection({
     publishDate: z.date().optional(),
     updateDate: z.date().optional(),
     draft: z.boolean().optional(),
+    lang: z.enum(['en', 'es', 'pt']).default('en'),
+
+    slug: z.string().optional(),
 
     title: z.string(),
     excerpt: z.string().optional(),

--- a/src/data/post/codigos-funcion-modbus-ejemplos.md
+++ b/src/data/post/codigos-funcion-modbus-ejemplos.md
@@ -1,0 +1,108 @@
+---
+publishDate: 2025-04-02T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/codigos-funcion-modbus-ejemplos
+title: "Códigos de función Modbus con ejemplos reales"
+excerpt: "Comprende los códigos Modbus más comunes y cómo implementarlos con seguridad en aplicaciones industriales."
+image: '~/assets/images/modbus.jpg'
+category: Automatización Industrial
+tags:
+  - modbus
+  - códigos de función
+metadata:
+  canonical: https://eduardovieira.dev/es/codigos-funcion-modbus-ejemplos
+---
+
+# Códigos de función Modbus con ejemplos reales
+
+Los códigos de función Modbus definen la acción que solicita un maestro al dispositivo esclavo. Estos ejemplos muestran cómo aplico los códigos más comunes al integrar PLC, drives y medidores de energía en planta.
+
+## 1. Leer bobinas (0x01)
+
+- **Caso de uso:** Consultar comandos de arranque/parada o salidas digitales.
+- **Consejo:** Agrupa bobinas contiguas para minimizar solicitudes.
+
+```python
+client.read_coils(address=0, count=8, unit=1)
+```
+
+## 2. Leer entradas discretas (0x02)
+
+- **Caso de uso:** Monitorear circuitos de seguridad (cortinas, puertas).
+- **Consejo:** Usa intervalos de sondeo separados para señales críticas y evitar demoras.
+
+```python
+client.read_discrete_inputs(address=0, count=16, unit=1)
+```
+
+## 3. Leer registros holding (0x03)
+
+- **Caso de uso:** Obtener valores de proceso, setpoints, contadores.
+- **Consejo:** Aplica escalado según la documentación.
+
+```python
+result = client.read_holding_registers(40010, count=4, unit=3)
+temperature = result.registers[0] / 10
+```
+
+## 4. Leer registros de entrada (0x04)
+
+- **Caso de uso:** Leer datos de sensores o medidores de energía de solo lectura.
+
+```python
+client.read_input_registers(address=0, count=6, unit=5)
+```
+
+## 5. Escribir una bobina (0x05)
+
+- **Caso de uso:** Comandos de inicio/paro o habilitar salidas.
+- **Consejo:** Confirma el estado con una lectura posterior; algunos equipos encolan escrituras.
+
+```python
+client.write_coil(address=4, value=True, unit=1)
+```
+
+## 6. Escribir un registro (0x06)
+
+- **Caso de uso:** Ajustar setpoints o modos (p. ej., referencia de velocidad de un drive).
+- **Consejo:** Valida rangos antes de escribir para evitar disparos.
+
+```python
+client.write_register(address=40020, value=1500, unit=2)
+```
+
+## 7. Escribir múltiples bobinas (0x0F) y registros (0x10)
+
+- **Caso de uso:** Descargar recetas, reiniciar contadores o conmutar múltiples salidas en simultáneo.
+- **Consejo:** Usa estos códigos para garantizar que todos los valores cambien en la misma transacción.
+
+```python
+client.write_coils(address=0, values=[True, False, True], unit=1)
+client.write_registers(address=40030, values=[120, 250, 370], unit=2)
+```
+
+## 8. Diagnóstico (0x08)
+
+- **Caso de uso:** Probar enlaces de comunicación o reiniciar contadores diagnósticos.
+
+```python
+client.diag_query(diag_code=0x0000, unit=1)  # devuelve los datos de la consulta
+```
+
+## 9. Códigos de excepción a vigilar
+
+| Código | Significado | Acción típica |
+| --- | --- | --- |
+| 0x01 | Función ilegal | El dispositivo no soporta la función |
+| 0x02 | Dirección de datos ilegal | Dirección fuera de rango; ajusta el mapa |
+| 0x03 | Valor de datos ilegal | Valor fuera de rango; revisa el escalado |
+| 0x06 | Dispositivo ocupado | Reduce el sondeo o agrega retardos |
+
+## 10. Consideraciones de seguridad
+
+- Valida cada escritura contra rangos seguros de operación.
+- Implementa permisos en la pasarela; no todos los usuarios deben escribir en equipos Modbus.
+- Registra todas las escrituras con ID de operador y marca de tiempo.
+
+Dominar los códigos de función es clave para integrar Modbus con confiabilidad. Complementa estos comandos con manejo de errores y controles de seguridad para mantener sistemas robustos.

--- a/src/data/post/comparativa-versiones-mqtt.md
+++ b/src/data/post/comparativa-versiones-mqtt.md
@@ -1,0 +1,60 @@
+---
+publishDate: 2025-04-11T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/comparativa-versiones-mqtt
+title: "Comparativa de versiones MQTT: 3.1.1 vs 5.0"
+excerpt: "Diferencias entre MQTT 3.1.1 y 5.0 para planificar actualizaciones y aprovechar nuevas funciones con criterio."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - mqtt
+  - versiones
+metadata:
+  canonical: https://eduardovieira.dev/es/comparativa-versiones-mqtt
+---
+
+# Comparativa de versiones MQTT: 3.1.1 vs 5.0
+
+La mayoría de despliegues industriales aún usan MQTT 3.1.1, pero la versión 5.0 incorpora mejoras que simplifican operaciones y aumentan la observabilidad. Esto es lo que cambia y cómo decido cuándo adoptarla.
+
+## 1. Gestión de sesión y estado
+
+| Función | MQTT 3.1.1 | MQTT 5.0 |
+| --- | --- | --- |
+| Expiración de sesión | Solo sesión limpia o persistente | Expiración configurable (segundos) |
+| Suscripciones compartidas | Extensiones específicas del broker | Estandarizadas |
+| Alias de tópico | No disponible | Reduce el tamaño del payload |
+
+## 2. Controles de mensajería mejorados
+
+- **Reason codes:** Acuses detallados para diagnosticar problemas rápidamente.
+- **Propiedades de usuario:** Metadata clave-valor por mensaje.
+- **Expiración de mensajes:** TTL por mensaje para datos sensibles al tiempo.
+
+## 3. Visibilidad operativa
+
+- **Paquetes de desconexión del servidor:** El broker puede explicar por qué cerró la conexión.
+- **Patrón request/response:** Los tópicos de respuesta estandarizan interacciones tipo RPC.
+- **Identificadores de suscripción:** Permiten rastrear qué suscripción entregó un mensaje.
+
+## 4. Cuándo permanecer en 3.1.1
+
+- Clientes heredados que no pueden actualizarse (dispositivos embebidos, librerías antiguas).
+- Entornos donde la simplicidad y la huella mínima son prioridad.
+- Cuando las funciones actuales del broker/cliente ya cubren tus necesidades vía extensiones.
+
+## 5. Cuándo adoptar 5.0
+
+- Necesitas suscripciones compartidas estandarizadas para balancear cargas analíticas.
+- La observabilidad es crítica; reason codes y propiedades de usuario mejoran el monitoreo.
+- Buscas reducir ancho de banda con alias de tópico y expiración de mensajes.
+
+## 6. Estrategia de migración
+
+1. Asegura que el broker soporte ambas versiones (HiveMQ, EMQX, Mosquitto ≥ 1.6).
+2. Actualiza clientes gradualmente y valida compatibilidad en staging.
+3. Usa negociación de características: los clientes anuncian lo que soportan en CONNECT.
+4. Ajusta políticas de seguridad para cubrir las nuevas funciones (las propiedades de usuario pueden contener datos sensibles).
+
+MQTT 5.0 es retrocompatible, así que puedes transicionar a tu ritmo. Evalúa los beneficios frente a tus objetivos y activa las capacidades 5.0 donde aporten ganancias operativas claras.

--- a/src/data/post/conectando-plcs-allen-bradley-nube.md
+++ b/src/data/post/conectando-plcs-allen-bradley-nube.md
@@ -1,8 +1,10 @@
 ---
 publishDate: 2025-06-18T00:00:00Z
 author: Eduardo Vieira
-title: "Connecting Allen‑Bradley PLCs to the Cloud with pycomm3 and Node‑RED"
-excerpt: "A field-tested architecture for reading, buffering, and visualizing Allen‑Bradley PLC data securely in the cloud."
+lang: es
+slug: es/conectando-plcs-allen-bradley-nube
+title: "Conectando PLC Allen-Bradley a la nube con pycomm3 y Node-RED"
+excerpt: "Arquitectura probada en planta para leer, almacenar y visualizar datos de PLC Allen-Bradley de forma segura en la nube."
 image: '~/assets/images/plc-allen-bradley.jpg'
 category: IIoT
 tags:
@@ -11,36 +13,36 @@ tags:
   - ethernet-ip
   - mqtt
 metadata:
-  canonical: https://eduardovieira.dev/conectando-plcs-allen-bradley-nube
+  canonical: https://eduardovieira.dev/es/conectando-plcs-allen-bradley-nube
 ---
 
-# Connecting Allen‑Bradley PLCs to the Cloud with pycomm3 and Node‑RED
+# Conectando PLC Allen-Bradley a la nube con pycomm3 y Node-RED
 
-Allen‑Bradley controllers still sit at the heart of many brownfield plants I modernize. This article documents the production recipe I use to expose their process data in near real time without compromising control integrity. It combines **pycomm3** for deterministic tag access, **Node‑RED** for orchestration, and MQTT for secure OT/IT handoff.
+Los controladores Allen-Bradley siguen siendo el corazón de muchas plantas brownfield que modernizo. Este artículo resume la receta de producción que utilizo para exponer sus datos de proceso casi en tiempo real sin comprometer la integridad del control. La solución combina **pycomm3** para accesos deterministas a tags, **Node-RED** para la orquestación y MQTT para un traspaso seguro entre OT e IT.
 
-## 1. Project Goals and Constraints
+## 1. Objetivos y restricciones del proyecto
 
-- Maintain ControlLogix and CompactLogix scan times below 20 ms.
-- Keep the solution **vendor-agnostic** so future upgrades can reuse the data pipeline.
-- Offer operators a buffered local dashboard that keeps running if the WAN link drops.
-- Enforce TLS, certificate authentication, and role-based topic permissions before anything leaves the plant network.
+- Mantener los tiempos de escaneo de ControlLogix y CompactLogix por debajo de los 20 ms.
+- Conservar la solución **agnóstica al fabricante** para reutilizar el pipeline de datos en futuras expansiones.
+- Ofrecer a los operadores un dashboard local con buffer que continúe funcionando ante caídas del enlace WAN.
+- Aplicar TLS, autenticación por certificados y permisos por tópico antes de que cualquier dato abandone la red de planta.
 
-## 2. Architecture Overview
+## 2. Arquitectura de referencia
 
 ```mermaid
 flowchart LR
-  PLC[Allen-Bradley PLC] -- EtherNet/IP --> Edge[Industrial PC \n + pycomm3]
-  Edge -- MQTT 8883/TLS --> Broker((Central MQTT Broker))
-  Edge -- OPC-UA --> Historian[(Plant Historian)]
-  Broker --> Apps[Dashboards, Analytics, CMMS]
+  PLC[PLC Allen-Bradley] -- EtherNet/IP --> Edge[PC industrial \n + pycomm3]
+  Edge -- MQTT 8883/TLS --> Broker((Broker MQTT central))
+  Edge -- OPC-UA --> Historian[(Historian de planta)]
+  Broker --> Apps[Dashboards, analítica, CMMS]
 ```
 
-1. **Edge Collector (Python):** Polls named tags at a cadence aligned with machine takt time, applies validation, and publishes JSON payloads.
-2. **Node‑RED Runtime:** Manages buffering, retry logic, and exposes a local dashboard for operations.
-3. **MQTT Broker:** HiveMQ or EMQX with TLS offload and enterprise security policies.
-4. **Downstream Consumers:** Business intelligence dashboards, maintenance alerts, and ERP connectors.
+1. **Colector en el edge (Python):** Consulta tags nominados a una cadencia alineada al takt time de la máquina, aplica validaciones y publica cargas en JSON.
+2. **Runtime Node-RED:** Gestiona buffer, lógica de reintento y expone un dashboard local para operaciones.
+3. **Broker MQTT:** HiveMQ o EMQX con descarga de TLS y políticas de seguridad empresariales.
+4. **Consumidores aguas abajo:** Dashboards de negocio, alertas de mantenimiento y conectores ERP.
 
-## 3. Building the Edge Collector with pycomm3
+## 3. Construyendo el colector edge con pycomm3
 
 ```python
 from datetime import datetime
@@ -74,37 +76,37 @@ with LogixDriver("192.168.10.15/1") as plc:
         time.sleep(1)
 ```
 
-### Recommended Practices
+### Buenas prácticas recomendadas
 
-- **Batch reads** when possible to minimize roundtrips.
-- Use **QoS 1** for stateful process data; reserve QoS 2 for recipes or commands.
-- Segment EtherNet/IP traffic on a dedicated VLAN and rate-limit MQTT publishes to protect the controller.
+- Realiza **lecturas por lotes** siempre que sea posible para reducir viajes a la red.
+- Utiliza **QoS 1** para datos de proceso con estado; reserva QoS 2 para recetas o comandos.
+- Separa el tráfico EtherNet/IP en una VLAN dedicada y limita la tasa de publicación MQTT para proteger el controlador.
 
-## 4. Orchestrating Node‑RED Flows
+## 4. Orquestación de flujos en Node-RED
 
-My typical flow contains four swimlanes:
+Mi flujo típico contiene cuatro carriles:
 
-1. **Inbound Tags:** Receives MQTT messages and writes to InfluxDB for trending.
-2. **Operator UI:** Dashboards with SP/ PV charts, alarm lists, and OEE widgets.
-3. **Command Handling:** Authenticates remote commands, validates ranges, and sends writes back to the PLC through a pycomm3 microservice.
-4. **Health Monitoring:** Heartbeat topics, watchdog timers, and e-mail/Teams notifications when data stops flowing.
+1. **Tags entrantes:** Recibe mensajes MQTT y los escribe en InfluxDB para trending.
+2. **UI de operación:** Dashboards con gráficos SP/PV, listados de alarmas y widgets de OEE.
+3. **Gestión de comandos:** Autentica órdenes remotas, valida rangos y envía escrituras al PLC mediante un microservicio pycomm3.
+4. **Monitoreo de salud:** Tópicos de heartbeat, temporizadores watchdog y alertas por e-mail/Teams cuando cesa el flujo de datos.
 
-Include the `node-red-contrib-cip-ethernet-ip` palette only if you need direct interactions from Node‑RED; otherwise keep traffic consolidated in Python for easier unit testing.
+Incluye el palette `node-red-contrib-cip-ethernet-ip` solo si necesitas interacción directa desde Node-RED; de lo contrario, mantén el tráfico consolidado en Python para facilitar las pruebas unitarias.
 
-## 5. Security and Reliability
+## 5. Seguridad y confiabilidad
 
-- **Certificates:** Issue unique device certificates via your corporate PKI; rotate them automatically with SCEP or Vault.
-- **Offline Buffering:** Implement a local SQLite or InfluxDB cache so the edge node keeps up to one shift of data during WAN outages.
-- **Change Management:** Version-control your tag lists, payload schemas, and flow exports; treat the gateway like production software.
-- **Diagnostics:** Publish metrics (CPU, RAM, packet loss) under a `/sys` topic tree for proactive maintenance.
+- **Certificados:** Emite certificados únicos por dispositivo usando tu PKI corporativa; rota automáticamente con SCEP o Vault.
+- **Buffer fuera de línea:** Implementa una caché local en SQLite o InfluxDB para que el nodo edge conserve hasta un turno de datos durante cortes WAN.
+- **Gestión de cambios:** Versiona listas de tags, esquemas de payload y exportaciones de flujos; trata el gateway como software de producción.
+- **Diagnósticos:** Publica métricas (CPU, RAM, pérdida de paquetes) bajo un árbol de tópicos `/sys` para mantenimiento proactivo.
 
-## 6. Commissioning Checklist
+## 6. Lista de verificación de puesta en marcha
 
-- Validate tag names and data types with the controls engineer.
-- Perform a failover test by unplugging the WAN and ensuring the plant keeps running.
-- Review firewall rules so only MQTT/TLS and OT diagnostic ports are open.
-- Train operators on the new dashboards and escalation paths.
+- Valida nombres y tipos de datos con el ingeniero de control.
+- Ejecuta una prueba de failover desconectando la WAN y comprobando que la planta siga operando.
+- Revisa las reglas de firewall para que solo queden abiertos MQTT/TLS y puertos de diagnóstico OT.
+- Capacita a los operadores en los nuevos dashboards y rutas de escalamiento.
 
-## 7. Lessons Learned
+## 7. Lecciones aprendidas
 
-The most successful rollouts pair incremental deployment (one production cell at a time) with clear ownership between controls, IT, and analytics teams. By respecting scan-time budgets and treating the edge gateway as critical infrastructure, you can unlock cloud insights while keeping Allen‑Bradley PLCs rock-solid on the plant floor.
+Los despliegues más exitosos combinan una implementación incremental (una celda de producción por vez) con una clara asignación de responsabilidades entre control, IT y analítica. Al respetar los presupuestos de scan-time y tratar el gateway edge como infraestructura crítica, desbloquearás insights en la nube mientras mantienes los PLC Allen-Bradley impecables en el piso de planta.

--- a/src/data/post/conectando-plcs-mitsubishi-codesys-modbus.md
+++ b/src/data/post/conectando-plcs-mitsubishi-codesys-modbus.md
@@ -1,6 +1,8 @@
 ---
 publishDate: 2025-04-30T00:00:00Z
 author: Eduardo Vieira
+lang: es
+slug: es/conectando-plcs-mitsubishi-codesys-modbus
 title: "Conectando PLC Mitsubishi y CODESYS a la Nube con Modbus"
 excerpt: "Metodología paso a paso para unificar controladores Mitsubishi y CODESYS en una misma plataforma IIoT utilizando Modbus y MQTT."
 image: '~/assets/images/plc-mitsubishi.jpg'
@@ -11,7 +13,7 @@ tags:
   - codesys
   - modbus
 metadata:
-  canonical: https://eduardovieira.dev/connecting-mitsubishi-plcs-modbus
+  canonical: https://eduardovieira.dev/es/conectando-plcs-mitsubishi-codesys-modbus
 ---
 
 # Conectando PLC Mitsubishi y CODESYS a la Nube con Modbus

--- a/src/data/post/controladores-industriales-risc-v-personalizados.md
+++ b/src/data/post/controladores-industriales-risc-v-personalizados.md
@@ -1,0 +1,85 @@
+---
+publishDate: 2025-03-21T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/controladores-industriales-risc-v-personalizados
+title: "Evaluación de controladores industriales RISC-V personalizados"
+excerpt: "Lecciones al prototipar un controlador industrial basado en RISC-V, desde pruebas de determinismo hasta mantenibilidad a largo plazo."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - risc-v
+  - sistemas embebidos
+  - industrial
+metadata:
+  canonical: https://eduardovieira.dev/es/controladores-industriales-risc-v-personalizados
+---
+
+# Evaluación de controladores industriales RISC-V personalizados
+
+Un cliente me pidió analizar si una plataforma RISC-V a medida podía sustituir controladores propietarios que ya estaban al final de su ciclo de vida en una línea de empaque especializada. Este es el marco de evaluación que utilizamos y los aprendizajes que dejó el prototipo.
+
+## 1. Motivaciones del negocio
+
+- **Presión de costos:** Las tarjetas de reemplazo del OEM superaban los USD 3,000 y tenían plazos de entrega de 16 semanas.
+- **Flexibilidad:** El cliente ajusta recetas de máquina con frecuencia y buscaba una plataforma compatible con toolchains modernos (Git, CI/CD, despliegues en contenedores).
+- **Apertura:** Evitar el bloqueo con proveedores y licenciamientos sorpresivos al escalar internacionalmente.
+
+## 2. Criterios para elegir hardware
+
+Analizamos tres SoM RISC-V con certificaciones de temperatura industrial:
+
+| Tarjeta | CPU | Opciones de E/S | Certificación industrial | Notas |
+| --- | --- | --- | --- | --- |
+| Vendor A SoM | 4 núcleos RV64 | 2x Ethernet, 4x CAN, 1x PCIe | CE/UL en proceso | Excelente soporte del fabricante |
+| Vendor B Module | Doble núcleo RV32 | EtherCAT, RS-485, E/S aisladas | CE/UL vigente | RAM limitada |
+| Vendor C Dev Kit | 8 núcleos RV64 | Ethernet gigabit, USB, SPI | Ninguna | Gran rendimiento pero sin certificaciones |
+
+Elegimos **Vendor B** para las pruebas piloto porque la E/S aislada integrada reducía el trabajo de PCB, aun cuando la memoria era ajustada.
+
+## 3. Pila de software
+
+- **RTOS:** Zephyr con el complemento de Time-Sensitive Networking (TSN) para Ethernet determinista.
+- **Middleware:** FreeModbus, un maestro EtherCAT personalizado y un cliente MQTT ligero.
+- **Capa de aplicación:** Texto estructurado convertido a C usando exportaciones PLCopen XML y compilado con GCC.
+- **Herramientas:** Pipelines de GitLab CI que cruzan compilaciones, ejecutan análisis estático (cppcheck) y publican artefactos en un registro interno.
+
+## 4. Determinismo y comportamiento en tiempo real
+
+Instrumenté el firmware con toggles GPIO y medí el jitter con un osciloscopio digital. Resultados:
+
+- **Tiempo de ciclo:** Tarea de 2 ms con jitter de ±60 µs bajo carga nominal.
+- **Carga de red:** Al habilitar MQTT con QoS 1 el jitter subió a ±120 µs; lo mitigamos delegando MQTT a un segundo núcleo.
+- **Latencia de interrupciones:** Máximo de 8 µs al manejar PDOs de EtherCAT; aceptable para los lazos de servos de la máquina.
+
+## 5. Endurecimiento industrial
+
+- **Gabinete:** Carrier para riel DIN con recubrimiento conformal para soportar humedad.
+- **Alimentación:** Entradas duales redundantes de 24 VDC con protección de polaridad inversa.
+- **Diagnóstico:** Consola UART dedicada para mantenimiento y bootloader seguro con actualización de firmware firmada.
+- **Ciberseguridad:** Módulo TPM 2.0 para almacenamiento de llaves, TLS mutuo para MQTT y atestación remota integrada con Azure DPS.
+
+## 6. Integración con la infraestructura existente
+
+Para evitar reescribir el HMI expusimos el mismo conjunto de nodos OPC UA que usaba el controlador original. Una capa de traducción mapeó las etiquetas internas a variables OPC UA, de modo que el SCADA existente se conectó sin cambios.
+
+## 7. Costo total de propiedad
+
+| Concepto | RISC-V personalizado | Repuesto legado |
+| --- | --- | --- |
+| BOM de hardware | USD 620 | USD 3,050 |
+| Desarrollo de firmware (estimado) | USD 45,000 | USD 0 (off-the-shelf) |
+| Certificación | USD 12,000 | Incluida |
+| Soporte anual | USD 6,000 | USD 18,000 |
+
+El punto de equilibrio llegó en el tercer año al considerar repuestos y menor tiempo de inactividad. El beneficio intangible: control total del roadmap y capacidad de corregir vulnerabilidades en nuestro propio calendario.
+
+## 8. Veredicto final
+
+Los controladores RISC-V personalizados no son reemplazos directos para cualquier planta, pero brillan cuando:
+
+- Necesitas combinaciones de E/S especializadas o redes deterministas.
+- La organización está lista para tratar el firmware de control como software moderno con prácticas DevOps.
+- El costo de ciclo de vida y la resiliencia de la cadena de suministro pesan más que la comodidad de los PLC comerciales.
+
+Para una adopción amplia invierte temprano en documentación, pruebas automatizadas y capacitación para mantenimiento. Con esos pilares, RISC-V puede convertirse en un diferenciador competitivo en programas de automatización industrial.

--- a/src/data/post/convertidor-texto-estructurado-plano-plc.md
+++ b/src/data/post/convertidor-texto-estructurado-plano-plc.md
@@ -1,0 +1,169 @@
+---
+title: "Modernizar el desarrollo PLC: convertir texto estructurado a texto plano para control de versiones y programación con IA"
+excerpt: "Cómo cerrar la brecha entre la programación de automatización industrial y las prácticas modernas de software con una herramienta que convierte código PLC a archivos de texto plano para Git y asistentes de IA."
+image: ~/assets/images/ai_programming.png
+category: Automatización Industrial
+tags:
+  - programación plc
+  - codesys
+  - control de versiones
+  - git
+  - texto estructurado
+  - automatización industrial
+  - programación ia
+metadata:
+  canonical: https://eduardovieira.dev/es/convertidor-texto-estructurado-plano-plc
+author: Eduardo Vieira
+publishDate: 2025-04-08T00:00:00Z
+lang: es
+slug: es/convertidor-texto-estructurado-plano-plc
+---
+
+## El eslabón perdido en el desarrollo PLC
+
+Los programadores de automatización industrial han enfrentado un reto constante: mientras el resto del mundo de software disfruta de control de versiones robusto, herramientas colaborativas y programación asistida por IA, el desarrollo PLC sigue aislado en entornos propietarios. Esta brecha genera varios problemas:
+
+1. **Control de versiones limitado:** Los PLC guardan código en archivos binarios que Git u otros VCS no pueden rastrear de forma útil.
+2. **Sin visualización de diffs:** Identificar cambios entre versiones es innecesariamente complicado.
+3. **Barreras de colaboración:** Varios ingenieros no pueden trabajar fácilmente en distintas partes del proyecto.
+4. **Brecha con la IA:** Los asistentes de código modernos no leen ni modifican archivos binarios de proyectos PLC.
+
+Para cerrar esta brecha desarrollé el **Convertidor de Texto Estructurado PLC a Texto Plano**, una herramienta open source que transforma proyectos CODESYS y ABB Automation Builder en archivos de texto controlables por versiones y aptos para programación asistida por IA.
+
+## Desbloquear flujos modernos para automatización
+
+La herramienta crea un flujo bidireccional entre el entorno PLC y archivos de texto plano:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/10.%20ai.png" alt="Integración con IDE" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+El convertidor permite exportar e importar:
+
+- Program Organization Units (POU)
+- Data Unit Types (DUT)
+- Métodos, funciones y bloques de función
+- Configuraciones de tareas
+- Propiedades, acciones y transiciones
+
+Al extraer el código fuente a texto plano habilitas varias capacidades clave:
+
+### 1. Control de versiones real con Git
+
+Con el código PLC en formato de texto aprovechas todo el potencial de Git:
+
+- Rastrear cambios significativos en lugar de diferencias binarias
+- Crear ramas de funcionalidades para desarrollo en paralelo
+- Revisar cambios con diffs claros antes de fusionar
+- Mantener un historial completo del código
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/12.%20git.png" alt="Integración con Git" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+### 2. Programación PLC asistida por IA
+
+Lo más atractivo es usar asistentes de código modernos con tu base PLC:
+
+- Obtener sugerencias inteligentes de autocompletado
+- Refactorizar lógica compleja con ayuda de IA
+- Generar documentación automáticamente
+- Identificar bugs y oportunidades de optimización
+
+### 3. Plantillas de proyecto más simples
+
+La herramienta añade funciones para gestionar plantillas:
+
+- Generar plantillas reutilizables
+- Actualizar proyectos desde plantillas
+- Estandarizar la estructura de código entre máquinas
+
+## Configuración del convertidor PLC-texto
+
+Poner en marcha el convertidor es sencillo.
+
+### Instalación
+
+1. Copia la carpeta Script Commands en tu instalación CODESYS o Automation Builder:
+   - CODESYS: `C:\Program Files\CODESYS 3.5.20.50\CODESYS\Script Commands`
+   - Automation Builder: `C:\Program Files\ABB\AB2.8\AutomationBuilder\Script Commands`
+2. Abre el entorno PLC sin cargar un proyecto.
+3. Selecciona **Tools → Customize** en el menú:
+   <p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/1.%20codesys.png" alt="Menú Customize" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+4. Selecciona o crea una toolbar y pulsa **Add Command...**:
+   <p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/2.%20toolbar.png" alt="Configuración de toolbar" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+5. En la categoría **ScriptEngine Commands** agrega los comandos **Export to Files** e **Import From Files**:
+   <p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/3.%20commands.png" alt="Añadir comandos" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+6. Verás los botones de exportación e importación en tu barra de herramientas:
+   <p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/4.%20buttons.png" alt="Botones Export/Import" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+## Uso del convertidor: flujo práctico
+
+Así integro la herramienta en mi flujo diario:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/5.%20project.png" alt="Nuevo proyecto" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+### Paso 1: organiza la estructura del proyecto
+
+Crea una carpeta `src` dentro de tu Application para contener todo lo que sincronizarás:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/6.%20src.png" alt="Organización" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+**Importante:** Solo se exporta/importa lo que está dentro de esa carpeta. Deja configuraciones de comunicación y componentes de sistema fuera porque el convertidor no los soporta.
+
+### Paso 2: exporta a texto plano
+
+Con el proyecto organizado, haz clic en **Export to Files** para extraer todo al sistema de archivos:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/7.%20export.png" alt="Proceso de exportación" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+Los archivos se generan siguiendo la estructura del proyecto:
+`<Project Name>/<Device Name>/<Application Name>/src/`
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/8.%20files.png" alt="Archivos generados" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+### Paso 3: edita con herramientas modernas
+
+Abre y edita los archivos con tu editor o IDE favorito:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/9.%20ide.png" alt="Edición en IDE" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+**Importante:** No elimines la línea `// --- BEGIN IMPLEMENTATION ---`; ayuda al script a distinguir entre declaraciones de variables y código.
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/10.%20ai.png" alt="Asistente IA" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+### Paso 4: importa de vuelta al entorno PLC
+
+Cuando estés listo, usa **Import From Files** para traer el código actualizado al proyecto:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/11.%20imported.png" alt="Código importado" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+### Paso 5: aprovecha el control de versiones
+
+Con el código en texto, realiza commits y sigue la evolución de tu lógica de control:
+
+<p><img src="https://raw.githubusercontent.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI/refs/heads/main/img/12.%20git.png" alt="Commits en Git" class="w-full rounded-md bg-gray-400 dark:bg-gray-700"></p>
+
+Conserva también el archivo binario del proyecto en el repositorio para referencia.
+
+## Buenas prácticas y limitaciones
+
+La herramienta mejora notablemente el flujo PLC, pero considera lo siguiente:
+
+### Buenas prácticas
+
+- Define una estructura de carpetas consistente entre proyectos.
+- Haz commit tanto de archivos de texto como del binario del proyecto.
+- Escribe mensajes de commit descriptivos sobre los cambios en la lógica.
+- Usa ramas para nuevas funciones y pruebas.
+
+### Limitaciones actuales
+
+- No soporta exportar/importar elementos de visualización.
+- Dispositivos de comunicación tienen soporte limitado.
+- La gestión de recetas debe permanecer fuera de la carpeta exportada.
+- Probado extensivamente en CODESYS V3.5 SP20.
+
+## Conclusión: llevar la programación PLC a la era moderna
+
+El Convertidor de Texto Estructurado a Texto Plano representa un puente entre la programación industrial tradicional y las prácticas modernas de software. Al habilitar control de versiones, colaboración y programación asistida por IA, aceleramos el desarrollo, mejoramos la calidad de código y reducimos la brecha de habilidades en automatización.
+
+La herramienta está disponible en [GitHub](https://github.com/eduardojvieira/PLC-Structured-Text-to-Plain-Text-for-Version-Control-and-AI) y recibe contribuciones de la comunidad.
+
+Para más detalles técnicos consulta la [documentación de scripting de CODESYS](https://help.codesys.com/webapp/idx-scriptingengine) o la ayuda local en `C:\<CODESYS INSTALL LOCATION>\CODESYS\Online Help\en\ScriptEngine.chm`.

--- a/src/data/post/direccionamiento-estructura-trama-modbus.md
+++ b/src/data/post/direccionamiento-estructura-trama-modbus.md
@@ -1,0 +1,116 @@
+---
+publishDate: 2025-03-30T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/direccionamiento-estructura-trama-modbus
+title: "Comprender el direccionamiento y la estructura de trama Modbus"
+excerpt: "Guía práctica para decodificar tramas Modbus RTU y TCP, con consejos para resolver problemas en campo."
+image: '~/assets/images/modbus.jpg'
+category: Automatización Industrial
+tags:
+  - modbus
+  - protocolo
+metadata:
+  canonical: https://eduardovieira.dev/es/direccionamiento-estructura-trama-modbus
+---
+
+# Comprender el direccionamiento y la estructura de trama Modbus
+
+Al integrar equipos heredados o construir una pasarela IIoT, dominar el framing Modbus ahorra horas de diagnóstico. Esta guía explica el modelo de direccionamiento y cómo se ensamblan las tramas RTU/TCP en proyectos reales.
+
+## 1. Direccionamiento lógico vs. físico
+
+Las direcciones Modbus son base cero, pero muchos manuales del fabricante usan notación base uno. Confirma siempre:
+
+- **40001** (manual) equivale al registro holding **dirección 0** en código.
+- **Bobinas** (0xxxx), **entradas discretas** (1xxxx), **registros de entrada** (3xxxx), **registros holding** (4xxxx).
+- El identificador de unidad importa en pasarelas que enlazan múltiples dispositivos.
+
+## 2. Anatomía de una trama RTU
+
+```
+| Dirección | Función | Datos ... | CRC |
+  1 byte     1 byte    N bytes    2 bytes
+```
+
+Ejemplo: lectura de dos registros holding del esclavo 0x11
+
+```
+Request: 11 03 00 6B 00 02 CRC
+Response: 11 03 04 02 2B 00 00 CRC
+```
+
+Consejos:
+
+- Respeta los **intervalos de silencio** de 3,5 tiempos de carácter entre tramas.
+- Alinea baudrate, paridad y bits de parada en todos los nodos.
+- Vigila errores de CRC por ruido; agrega blindaje y buena puesta a tierra.
+
+## 3. Anatomía de una trama TCP
+
+Modbus TCP encapsula los datos PDU en un encabezado MBAP:
+
+```
+| ID de transacción | ID de protocolo | Longitud | Unit ID | Función | Datos |
+       2 bytes            2 bytes        2 bytes    1 byte    1 byte   N bytes
+```
+
+- El ID de transacción ayuda a casar respuestas en clientes asíncronos.
+- El ID de protocolo siempre es `0x0000`.
+- La longitud incluye Unit ID + Function + Data.
+
+## 4. Mapeo de dispositivos a direcciones
+
+Crea una hoja de cálculo con el mapa de registros que incluya:
+
+| Tag | Tipo | Dirección | Escalado | Unidades | Notas |
+| --- | --- | --- | --- | --- | --- |
+| Oven_Temp | Holding Register | 40010 | ÷10 | °C | Palabra PLC |
+| Valve_CMD | Coil | 00005 | — | BOOL | Solo escritura |
+
+Mantén el mapa versionado y compártelo con equipos OT/IT.
+
+## 5. Flujo de resolución de problemas
+
+1. **Verifica cableado** y resistencias de terminación (120 Ω) en redes RS-485.
+2. **Usa un analizador de protocolo** (Modbus Poll, QModMaster, Wireshark) para inspeccionar tramas.
+3. **Revisa diagnósticos:** muchos PLC exponen contadores de errores Modbus (timeout, CRC, excepciones).
+4. **Consulta códigos de excepción** (por ejemplo `0x02` dirección ilegal de datos) para ajustar consultas.
+
+## 6. Decodificador Python de ejemplo
+
+```python
+import struct
+
+EXCEPTION_CODES = {
+    0x01: "Función ilegal",
+    0x02: "Dirección de datos ilegal",
+    0x03: "Valor de datos ilegal",
+    0x04: "Falla del esclavo"
+}
+
+
+def parse_modbus_response(frame: bytes) -> dict:
+    address, function = frame[0], frame[1]
+    length = frame[2]
+    data = frame[3:3 + length]
+    crc = struct.unpack('<H', frame[-2:])[0]
+
+    if function & 0x80:
+        return {"address": address, "error": EXCEPTION_CODES.get(data[0], "Desconocido"), "crc": crc}
+
+    return {
+        "address": address,
+        "function": function,
+        "data": list(data),
+        "crc": crc,
+    }
+```
+
+## 7. Estrategias para plantas reales
+
+- Implementa **pruebas automáticas** que validen mapas Modbus tras cambios de firmware.
+- Documenta **retardos de comunicación** aceptables por celda; sirven para detectar congestión.
+- Considera **gateways redundantes** cuando múltiples líneas dependen de la misma infraestructura Modbus.
+
+Dominar el direccionamiento y las tramas de Modbus aporta tranquilidad a integradores y operadores. Con mapas claros, monitoreo y buenas prácticas de cableado, el protocolo sigue siendo un aliado confiable en la automatización moderna.

--- a/src/data/post/diseno-payloads-mqtt-iiot.md
+++ b/src/data/post/diseno-payloads-mqtt-iiot.md
@@ -1,0 +1,87 @@
+---
+publishDate: 2025-04-09T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/diseno-payloads-mqtt-iiot
+title: "Diseñar formatos de payload MQTT para IIoT"
+excerpt: "Cómo estructurar payloads MQTT útiles para operaciones, analítica y sistemas empresariales sin generar deuda técnica."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - mqtt
+  - payloads
+metadata:
+  canonical: https://eduardovieira.dev/es/diseno-payloads-mqtt-iiot
+---
+
+# Diseñar formatos de payload MQTT para IIoT
+
+MQTT facilita mover datos, pero el formato del payload define si los sistemas aguas abajo pueden aprovecharlos. Así diseño payloads que escalan entre operaciones, TI y analítica.
+
+## 1. Elige la codificación adecuada
+
+| Codificación | Ventajas | Desventajas | Úsalo cuando |
+| --- | --- | --- | --- |
+| JSON | Legible, tooling ubicuo | Payload más grande, parseo más lento | Telemetría general, dashboards |
+| Binario (protobuf, MessagePack) | Compacto, rápido | Requiere gestión de esquemas | Enlaces con poco ancho de banda |
+| CSV | Simple, bajo overhead | Tipos ambiguos, poca metadata | Integraciones heredadas |
+| Sparkplug B | Estandarizado, con estado | Requiere clientes específicos | Brokers MQTT empresariales |
+
+La mayoría de los proyectos inician con JSON por su legibilidad y evolucionan a Sparkplug B al escalar.
+
+## 2. Define un contrato de datos
+
+- Usa nombres de campos consistentes (snake_case o camelCase) y documéntalos.
+- Incluye timestamps (`ISO 8601`), unidades y flags de calidad.
+- Versiona los payloads (`schema_version`) para manejar cambios.
+
+Ejemplo JSON:
+
+```json
+{
+  "schema_version": "1.2",
+  "asset": "linea01.envasadora",
+  "timestamp": "2025-04-09T14:30:05Z",
+  "process": {
+    "oee": 0.87,
+    "temperatura_c": 192.5,
+    "presion_bar": 4.2
+  },
+  "alarms": [
+    {"code": 102, "severity": "high", "message": "Puerta abierta"}
+  ]
+}
+```
+
+## 3. Soporta localización y unidades
+
+- Estandariza unidades (preferentemente SI) y convierte en el borde si es necesario.
+- Incluye catálogos de mensajes por idioma cuando los operadores hablan múltiples lenguas.
+
+## 4. Maneja lotes y streaming
+
+- Para señales de cambio rápido, envía actualizaciones incrementales solo con campos modificados.
+- Para cargas históricas, empaqueta arreglos de mediciones con timestamps de inicio/fin.
+
+## 5. Incluye calidad y metadata de origen
+
+- Añade campos de `quality` (good, bad, uncertain) e intervalos de muestreo.
+- Identifica la fuente (`plc_id`, `gateway_id`, versión de firmware) para trazabilidad.
+
+## 6. Consideraciones de seguridad
+
+- Firma los payloads o usa TLS con autenticación mutua.
+- Evita incrustar secretos o credenciales dentro del payload.
+- Cifra campos sensibles a nivel aplicación si lo exige la normativa.
+
+## 7. Pruebas y validación
+
+- Crea JSON Schemas o definiciones protobuf y valida mensajes en pipelines CI.
+- Usa gemelos digitales o simuladores para reproducir payloads antes del despliegue.
+
+## 8. Documentación y gobierno
+
+- Mantén las definiciones en un repositorio compartido con registro de cambios.
+- Comunica deprecaciones con anticipación y soporta esquemas duales durante la transición.
+
+Un payload bien estructurado convierte a MQTT en la columna vertebral de la manufactura inteligente. Trátalo como un contrato de API y los equipos aguas abajo construirán sobre él con confianza.

--- a/src/data/post/diseno-sistemas-embebidos-industria.md
+++ b/src/data/post/diseno-sistemas-embebidos-industria.md
@@ -1,0 +1,73 @@
+---
+publishDate: 2025-02-17T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/diseno-sistemas-embebidos-industria
+title: "Diseño de sistemas embebidos para aplicaciones industriales"
+excerpt: "Guías que sigo al diseñar soluciones embebidas que deben sobrevivir en planta y dialogar con sistemas OT."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - sistemas embebidos
+  - diseño industrial
+  - hardware
+metadata:
+  canonical: https://eduardovieira.dev/es/diseno-sistemas-embebidos-industria
+---
+
+# Diseño de sistemas embebidos para aplicaciones industriales
+
+Las plantas castigan a la electrónica. Las variaciones de temperatura, el ruido eléctrico y la demanda de operación continua convierten el diseño embebido industrial en una disciplina aparte. Así abordo la construcción de dispositivos que prosperan en piso de planta.
+
+## 1. Empieza por el contexto operativo
+
+- **Expectativas de ciclo de vida:** Muchas máquinas operan 15 años o más. Documenta cómo se gestionarán actualizaciones de firmware y repuestos.
+- **Cumplimiento:** Define qué normas aplican (UL 508A, IEC 61010, CE, FCC).
+- **Integración:** Identifica con qué PLC, HMI y SCADA debe comunicarse el dispositivo.
+
+## 2. Principios de diseño de hardware
+
+- Selecciona componentes con **rango de temperatura industrial** (–40 °C a 85 °C) y sobredimensiona tensiones al menos 20%.
+- Proporciona **aislamiento galvánico** en E/S expuestas a equipos de alto voltaje.
+- Incorpora protección contra transientes (diodos TVS) y puesta a tierra adecuada para sobrevivir al ruido.
+- Diseña módulos reemplazables en campo (p. ej., tarjetas de comunicación) para incorporar protocolos futuros.
+
+## 3. Arquitectura de firmware
+
+- Usa RTOS como Zephyr o FreeRTOS para separar tareas deterministas de servicios no críticos.
+- Implementa watchdogs, detección de brownout y rutinas de estado seguro en las que confíen los operadores.
+- Ofrece telemetría estructurada (MQTT, OPC UA) para monitorear salud y desempeño.
+
+## 4. Pila de comunicaciones
+
+Un producto embebido moderno debe hablar lenguajes OT e IT:
+
+| Capa | Protocolos |
+| --- | --- |
+| Fieldbus | Modbus RTU/TCP, CANopen, EtherCAT |
+| Mensajería | MQTT (Sparkplug B), AMQP |
+| Configuración | APIs REST/GraphQL con control de acceso basado en roles |
+
+## 5. Seguridad desde el diseño
+
+- Arranque seguro con imágenes de firmware firmadas.
+- Credenciales únicas por dispositivo, idealmente gestionadas por un módulo de seguridad hardware.
+- Almacenamiento cifrado para secretos y certificados.
+- Atestación remota para demostrar integridad antes de permitir acceso a la red.
+
+## 6. Pruebas y validación
+
+- **Ambientales:** Ciclos térmicos, pruebas de vibración y verificación de protección IP.
+- **EMC:** Ensayos de emisiones e inmunidad conducidas y radiadas según IEC 61000.
+- **Funcionales:** Simulaciones hardware-in-the-loop con bancos de prueba PLC para validar comportamiento determinista.
+- **Pilotos en campo:** Despliega unidades con registro diagnóstico para capturar casos reales.
+
+## 7. Mantenibilidad y soporte
+
+- Documenta esquemas, BOM y flujos de firmware en un repositorio accesible a mantenimiento.
+- Proporciona logging remoto y mecanismos de actualización OTA que respeten el control de cambios.
+- Ofrece guías de diagnóstico claras con indicadores LED y puertos de servicio.
+
+## 8. Lecciones aprendidas
+
+Los proyectos prosperan cuando control, IT y mantenimiento colaboran desde el día uno. Trata los dispositivos embebidos como activos de largo plazo que requieren planeación de ciclo de vida. Con hardware robusto y firmware seguro bien diseñado, puedes entregar soluciones embebidas que eleven las operaciones industriales durante años.

--- a/src/data/post/fundamentos-mqtt-pub-sub.md
+++ b/src/data/post/fundamentos-mqtt-pub-sub.md
@@ -1,0 +1,92 @@
+---
+publishDate: 2025-04-23T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/fundamentos-mqtt-pub-sub
+title: "Fundamentos de MQTT: publish/subscribe, brokers y clientes"
+excerpt: "Cómo la arquitectura publish/subscribe de MQTT mantiene el flujo de datos entre OT e IT de forma confiable."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - mqtt
+  - iiot
+  - publish/subscribe
+metadata:
+  canonical: https://eduardovieira.dev/es/fundamentos-mqtt-pub-sub
+---
+
+# Fundamentos de MQTT: publish/subscribe, brokers y clientes
+
+MQTT es mi protocolo de cabecera para conectar equipos de planta con plataformas analíticas. Su modelo publish/subscribe desacopla productores y consumidores, ideal para unir OT e IT. Así encajan las piezas en despliegues reales.
+
+## 1. Publish/subscribe en palabras simples
+
+- **Publishers** envían mensajes a tópicos (p. ej., `planta/linea1/horno`).
+- **Subscribers** reciben mensajes de los tópicos que les interesan.
+- **Broker** se ubica en medio, autentica clientes, enruta mensajes y puede retener el último valor.
+
+A diferencia de protocolos request/response, los publicadores y suscriptores no necesitan conocerse, lo que simplifica el escalado.
+
+## 2. Diagrama de arquitectura MQTT
+
+```mermaid
+flowchart LR
+  PLC[PLC / Gateway de borde] --> Broker((Broker MQTT))
+  Sensor[Sensor inteligente] --> Broker
+  Broker --> Dashboard[Dashboards / BI]
+  Broker --> CMMS[CMMS]
+  Broker --> Twin[Gemelo digital]
+```
+
+## 3. Calidad de servicio (QoS)
+
+- **QoS 0:** “Como máximo una vez” – mejor esfuerzo. Úsalo para telemetría no crítica.
+- **QoS 1:** “Al menos una vez” – requiere acuse. Útil para valores de proceso y alarmas.
+- **QoS 2:** “Exactamente una vez” – handshake de dos fases. Resérvalo para comandos o transacciones sensibles.
+
+Elige QoS por tópico según criticidad y estabilidad de red.
+
+## 4. Ejemplo de cliente
+
+```python
+import json
+from paho.mqtt.client import Client
+
+client = Client(client_id="edge-linea1")
+client.tls_set("ca.pem", "edge.pem", "edge.key")
+client.username_pw_set("linea1", "pass")
+client.connect("broker.planta", 8883)
+
+client.publish("planta/linea1/temperatura", json.dumps({"valor": 87.5}), qos=1)
+client.subscribe("planta/linea1/comandos/#", qos=1)
+```
+
+## 5. Mensajes retenidos y Last Will
+
+- **Retained Messages:** El broker almacena el último mensaje de un tópico. Perfecto para dashboards que necesitan un valor inmediato.
+- **Last Will and Testament:** Configura a los clientes para anunciar desconexiones inesperadas y alertar al mantenimiento.
+
+## 6. Consejos de diseño de tópicos
+
+- Usa jerarquías: `planta/linea/estacion/parametro`.
+- Reserva prefijos para monitoreo del sistema (`planta/linea1/_sys/heartbeat`).
+- Evita espacios y mantén los tópicos en minúsculas para consistencia.
+
+## 7. Esenciales de seguridad
+
+- Obliga TLS con certificados de cliente.
+- Usa ACL para restringir qué tópicos puede publicar/suscribirse cada cliente.
+- Rota credenciales y certificados periódicamente.
+- Monitorea conteo de conexiones y tasas de publicación anómalas.
+
+## 8. Estrategias de escalado
+
+- Despliega brokers en clúster (HiveMQ, EMQX, Mosquitto con bridging) para redundancia.
+- Usa suscripciones compartidas para balancear carga en consumidores.
+- Integra con IAM empresarial para gestionar usuarios centralizadamente.
+
+## 9. Puente entre OT e IT
+
+Combina MQTT con gateways edge que normalizan datos de PLC en payloads estructurados. Servicios aguas abajo—dashboards, CMMS, machine learning—consumen los mismos streams sin integraciones punto a punto.
+
+La simplicidad de MQTT esconde su potencia. Con diseño disciplinado de tópicos, selección de QoS y controles de seguridad, se convierte en la columna vertebral de arquitecturas IIoT resilientes.

--- a/src/data/post/gateway-iiot-raspberry-pi-produccion.md
+++ b/src/data/post/gateway-iiot-raspberry-pi-produccion.md
@@ -1,0 +1,108 @@
+---
+publishDate: 2025-03-15T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/gateway-iiot-raspberry-pi-produccion
+title: "Construir una pasarela IIoT de nivel industrial con Raspberry Pi"
+excerpt: "Convierte un Raspberry Pi en una pasarela IIoT robusta que una PLCs, sensores y analítica en la nube de forma segura."
+image: '~/assets/images/raspberry-pi.jpg'
+category: IIoT
+tags:
+  - raspberry pi
+  - iiot
+  - gateway industrial
+metadata:
+  canonical: https://eduardovieira.dev/es/gateway-iiot-raspberry-pi-produccion
+---
+
+# Construir una pasarela IIoT de nivel industrial con Raspberry Pi
+
+Uso con frecuencia pasarelas basadas en Raspberry Pi como compañeras ágiles de los PLC tradicionales. Con el diseño adecuado pueden manejar cargas industriales de forma confiable. Esta guía resume el plano que sigo desde la selección de hardware hasta el endurecimiento de seguridad.
+
+## 1. Base de hardware
+
+- **Modelo:** Raspberry Pi 4/5 con 8 GB de RAM para tener margen suficiente.
+- **Almacenamiento:** MicroSD grado industrial o, mejor, NVMe/SSD vía USB 3.0.
+- **Gabinete:** Caja para riel DIN con ventilación adecuada y disipadores opcionales.
+- **Alimentación:** Fuente industrial de 24 VDC con supresión de picos y respaldo UPS.
+
+## 2. Sistema operativo y configuración inicial
+
+```bash
+sudo raspi-config  # habilita SSH, ajusta idioma/huso horario, expande el filesystem
+sudo apt update && sudo apt upgrade
+sudo apt install docker.io docker-compose fail2ban unattended-upgrades
+```
+
+- Deshabilita interfaces que no uses (Bluetooth, Wi-Fi).
+- Asigna IPs estáticas en las VLAN OT e IT usando NICs USB separados.
+- Configura systemd-journald para enviar logs a un servidor syslog remoto.
+
+## 3. Servicios contenerizados
+
+```yaml
+version: '3.8'
+services:
+  mqtt:
+    image: eclipse-mosquitto:2
+    volumes:
+      - ./mosquitto:/mosquitto
+    ports:
+      - "8883:8883"
+  node-red:
+    image: nodered/node-red:latest
+    volumes:
+      - ./data/node-red:/data
+    ports:
+      - "1880:1880"
+  collector:
+    build: ./collector
+    restart: always
+```
+
+- Mantén los contenedores ligeros y define límites de recursos (CPU shares, memoria).
+- Usa Watchtower o jobs de CI/CD para actualizaciones controladas.
+
+## 4. Esqueleto de colector en Python
+
+```python
+import time, json
+from pycomm3 import LogixDriver
+from paho.mqtt.client import Client
+
+TAGS = ["Machine.Temp", "Machine.State", "Machine.Alarm"]
+
+client = Client(client_id="edge-gateway")
+client.tls_set("ca.pem", "gateway.pem", "gateway.key")
+client.connect("mqtt.company.com", 8883)
+
+with LogixDriver("192.168.10.15/1") as plc:
+    while True:
+        values = {tag: LogixDriver(tag).value for tag in TAGS}
+        payload = json.dumps({"ts": time.time(), "data": values})
+        client.publish("plant/line1/plc", payload, qos=1)
+        time.sleep(1)
+```
+
+Sustituye `pycomm3` por `pymodbus`, `snap7` o cualquier cliente de protocolo que necesites.
+
+## 5. Lista de endurecimiento de seguridad
+
+- Obliga a usar claves SSH y deshabilita logins por contraseña.
+- Implementa reglas de firewall con `ufw` o `nftables`; abre solo los puertos necesarios.
+- Configura `fail2ban` para bloquear ataques de fuerza bruta.
+- Rota certificados automáticamente con un gestor de secretos o un cron que consulte tu PKI.
+
+## 6. Observabilidad
+
+- Expón métricas con Prometheus Node Exporter y cAdvisor.
+- Envía logs a un stack centralizado (ELK, Graylog).
+- Configura tópicos de latido para supervisar la salud de la pasarela (`/sistema/latido`).
+
+## 7. Mantenimiento y ciclo de vida
+
+- Conserva una imagen dorada y scripts de Ansible para reconstruir pasarelas rápidamente.
+- Documenta procedimientos para reemplazar tarjetas SD o hardware en caso de falla.
+- Agenda pruebas trimestrales de baterías UPS y ciclos de actualización.
+
+Con ingeniería disciplinada, las pasarelas Raspberry Pi se convierten en aliadas confiables para iniciativas IIoT: aceleran la captura de datos, habilitan visibilidad remota y amplían el alcance de tu flota de PLC.

--- a/src/data/post/gemelos-digitales-mantenimiento-practico.md
+++ b/src/data/post/gemelos-digitales-mantenimiento-practico.md
@@ -1,0 +1,85 @@
+---
+publishDate: 2025-05-05T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/gemelos-digitales-mantenimiento-practico
+title: "Gemelos digitales para mantenimiento práctico: una hoja de ruta"
+excerpt: "Enfoque pragmático para construir gemelos digitales útiles para los equipos de mantenimiento, desde la captura de datos hasta la simulación."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - gemelos digitales
+  - mantenimiento
+  - simulación
+metadata:
+  canonical: https://eduardovieira.dev/es/gemelos-digitales-mantenimiento-practico
+---
+
+# Gemelos digitales para mantenimiento práctico: una hoja de ruta
+
+Los gemelos digitales suelen verse como demos llamativas. En mis proyectos se convierten en herramientas de uso diario porque se diseñan pensando en los resultados de mantenimiento. Esta hoja de ruta resume los pasos que sigo para entregar gemelos que mejoran la disponibilidad sin saturar a los equipos.
+
+## 1. Aclara los casos de uso de mantenimiento
+
+Empieza con los escenarios que enfrenta el equipo cada semana:
+
+- Diagnosticar fallas intermitentes que aparecen bajo condiciones específicas.
+- Capacitar técnicos nuevos sin poner en riesgo la producción.
+- Planificar acciones correctivas durante paradas programadas.
+
+Si un caso de uso no reduce tiempos muertos, mejora la seguridad o acelera la capacitación, queda fuera del alcance.
+
+## 2. Construye una base de datos confiable
+
+1. **Mapeo de tags:** Exporta tablas de símbolos del PLC y alinéalas con la jerarquía de equipos (ISA-95, IDs de activo).
+2. **Verificación de calidad:** Valida rangos, unidades y frecuencias de muestreo; registra anomalías en una cola de excepciones.
+3. **Sincronización con el historiador:** Almacena datos de alta resolución localmente para soportar repeticiones, y envía agregados a la nube para analítica.
+
+## 3. Modela el sistema de forma incremental
+
+- **Nivel 0 — gemelo de conectividad:** Refleja valores actuales de sensores/actuadores y alarmas. Útil para diagnóstico remoto.
+- **Nivel 1 — gemelo de comportamiento:** Añade modelos físicos o basados en datos (curvas de bombas, modelos térmicos) para predecir estados a corto plazo.
+- **Nivel 2 — gemelo de escenarios:** Permite simulaciones “what-if” para evaluar procedimientos de mantenimiento o cambios de receta.
+
+Solo avanza al siguiente nivel cuando el anterior entrega valor y cuenta con adopción.
+
+## 4. Ejemplo de toolchain
+
+```mermaid
+flowchart LR
+  PLC[PLC / Gateway de borde] --> Historian[(BD de series de tiempo)]
+  Historian --> TwinEngine[Motor del gemelo digital]
+  TwinEngine --> HMI[Frontend 3D/2D]
+  TwinEngine --> CMMS[Sistema de mantenimiento]
+  TwinEngine --> Analytics[Analítica / IA]
+```
+
+- **Motor del gemelo:** Uso TwinCAT Analytics o microservicios Python con modelos de espacio de estados.
+- **Frontend:** Combino un modelo 3D ligero (Unity WebGL o Three.js) con tableros 2D construidos en Grafana o Power BI.
+- **Integración:** APIs bidireccionales con el CMMS (Fiix, UpKeep) para abrir órdenes de trabajo directamente desde el gemelo.
+
+## 5. Involucra a mantenimiento
+
+- Realiza talleres con técnicos para mapear los puntos de dolor y validar maquetas de UI.
+- Graba sesiones de expertos diagnosticando fallas y conviértelas en procedimientos guiados dentro del gemelo.
+- Implementa widgets de retroalimentación para que pidan nuevos escenarios o reporten tags faltantes.
+
+## 6. Métricas clave a monitorear
+
+| KPI | Definición | Objetivo |
+| --- | --- | --- |
+| Mean Time to Diagnose (MTTD) | Tiempo promedio para identificar la causa raíz | Reducir 30% en 6 meses |
+| Eficiencia de capacitación | Tiempo para que un técnico complete su primera intervención en solitario | Reducir 25% |
+| Tiempo de inactividad evitado | Horas ahorradas al planificar con el gemelo | Medir mensualmente |
+
+## 7. Gobernanza y seguridad
+
+- Usa control de acceso basado en roles; mantenimiento puede ver/anotar, ingeniería modifica modelos e IT gestiona la infraestructura.
+- Versiona los modelos del gemelo igual que el código de control; cada liberación debe probarse en staging.
+- Cifra el tráfico entre el motor del gemelo y los frontends, especialmente cuando habilitas acceso remoto.
+
+## 8. Caso de éxito
+
+En una planta de alimentos construimos un gemelo de nivel 2 para un horno de túnel térmico. Mantenimiento podía ensayar el ajuste de quemadores antes de entrar a la zona caliente, reduciendo el tiempo por ajuste de 2 horas a 35 minutos. El gemelo también detectó desequilibrios de flujo de aire con anticipación, evitando problemas de calidad.
+
+Los gemelos digitales funcionan cuando se tratan como herramientas operativas, no solo proyectos de visualización. Empieza por los resultados de mantenimiento, itera junto al personal técnico y mantén la calidad de datos al frente.

--- a/src/data/post/ia-edge-industria-guia-practica.md
+++ b/src/data/post/ia-edge-industria-guia-practica.md
@@ -1,0 +1,85 @@
+---
+publishDate: 2025-04-07T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/ia-edge-industria-guia-practica
+title: "IA en el borde para manufactura: guía práctica de implementación"
+excerpt: "Pasos para llevar una prueba de concepto de IA perimetral a producción: etiquetado, despliegue compatible con OT y operación sostenible."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - ia perimetral
+  - visión por computadora
+  - automatización industrial
+metadata:
+  canonical: https://eduardovieira.dev/es/ia-edge-industria-guia-practica
+---
+
+# IA en el borde para manufactura: guía práctica de implementación
+
+La IA en el borde crea valor cuando complementa a operarios y sistemas de control sin añadir fragilidad. Después de desplegar múltiples proyectos de visión y detección de anomalías en planta, estas prácticas son las que más impacto generan.
+
+## 1. Define el caso de uso con claridad
+
+- **Detección de defectos:** Refuerza a los inspectores de visión con IA que marque anomalías que podrían pasar desapercibidas.
+- **Salud de activos:** Monitorea firmas de vibración para anticipar fallas en rodamientos.
+- **Cumplimiento de seguridad:** Detecta uso de EPP en estaciones de trabajo.
+
+Prioriza casos donde la IA automatiza inspecciones visuales repetitivas o analiza señales de alta frecuencia más rápido que un humano.
+
+## 2. Recolección y etiquetado ajustados a la realidad OT
+
+1. Captura datos durante operación normal y anómala; programa “data sprints” en paros planificados para no afectar la producción.
+2. Etiqueta la data con ingenieros de proceso y operadores presentes: el contexto es clave.
+3. Guarda metadatos (línea, turno, receta) junto a las muestras para que el modelo aprenda variaciones de proceso.
+
+## 3. Elige una plataforma perimetral industrial
+
+| Requisito | Recomendación |
+| --- | --- |
+| Entorno hostil | PCs industriales con refrigeración sin ventiladores y tolerancia a vibración |
+| Integración determinista | Linux en tiempo real o runtimes de contenedores con asignación fija de CPU |
+| Conectividad | NICs duales para separar redes OT e IT |
+| Seguridad | Chips TPM, arranque seguro, artefactos de modelo firmados |
+
+## 4. Ciclo de vida del modelo
+
+```mermaid
+flowchart LR
+  Data[Captura en el borde] --> Labeling[Etiquetado y QA]
+  Labeling --> Train[Entrenamiento del modelo]
+  Train --> Package[Contenerización y optimización]
+  Package --> Deploy[Despliegue perimetral]
+  Deploy --> Monitor[Monitoreo de desempeño]
+  Monitor --> Retrain[Reentrenamiento programado]
+```
+
+- **Entrenamiento:** Parte de arquitecturas probadas (YOLOv8 para visión, autoencoders para detectar anomalías).
+- **Optimización:** Utiliza TensorRT u OpenVINO para cuantizar y acelerar inferencia sin perder precisión.
+- **Despliegue:** Empaqueta modelos como contenedores con health checks; integra vía MQTT o APIs REST con SCADA/HMI.
+- **Monitoreo:** Sigue precisión/recall y deriva; activa reentrenamiento cuando los indicadores lo pidan.
+
+## 5. Integración con sistemas OT
+
+- Expón las salidas del modelo como variables OPC UA o tópicos MQTT (`/linea01/vision/defectos`).
+- Añade umbrales configurables para que los operadores ajusten la agresividad del modelo.
+- Registra cada decisión de IA con recortes de imagen y metadatos para trazabilidad.
+- Provee modo manual para mantener la producción si el servicio de IA cae.
+
+## 6. Gestión del cambio y capacitación
+
+- Ejecuta pilotos en los que las decisiones de IA sean solo consultivas antes de automatizar respuestas.
+- Capacita a los operadores en la interpretación de dashboards y la confirmación de eventos.
+- Documenta actualizaciones a procedimientos y asegura que mantenimiento sepa reiniciar o actualizar contenedores.
+
+## 7. Ciberseguridad
+
+- Firma los paquetes de modelos y verifica firmas antes de desplegar.
+- Restringe el acceso a Internet; las actualizaciones deben pasar por pipelines controlados de CI/CD.
+- Usa VLAN y firewalls para aislar los equipos perimetrales de las redes PLC críticas.
+
+## 8. Cómo medir el éxito
+
+Define los KPIs desde el inicio: menos rechazos falsos, menor tiempo de inactividad o análisis de causa raíz más veloz. En un proyecto, la IA perimetral redujo un 40% el tiempo de inspección manual y recuperó la inversión en un trimestre.
+
+La IA en el borde rinde frutos cuando se integra con operaciones, se apoya en prácticas disciplinadas de datos y corre sobre hardware industrial robusto. Trátala como parte del stack de automatización—no como un experimento—y los resultados llegarán.

--- a/src/data/post/implementacion-iiot-guia.md
+++ b/src/data/post/implementacion-iiot-guia.md
@@ -1,0 +1,73 @@
+---
+publishDate: 2025-02-03T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/implementacion-iiot-guia
+title: "Implementar IIoT industrial: playbook paso a paso"
+excerpt: "Del piloto al despliegue masivo, este playbook resume las fases que sigo para que las iniciativas IIoT perduren."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - iiot
+  - estrategia
+  - automatización industrial
+metadata:
+  canonical: https://eduardovieira.dev/es/implementacion-iiot-guia
+---
+
+# Implementar IIoT industrial: playbook paso a paso
+
+Las iniciativas IIoT prosperan cuando operaciones, TI y negocio se alinean desde el inicio. Tras liderar programas en fabricantes de toda América, este playbook es el que entrega resultados sostenibles.
+
+## Fase 1 — Descubrir
+
+1. **Entrevistas con interesados:** Habla con operadores, mantenimiento, calidad y directivos para identificar dolores y métricas de éxito.
+2. **Inventario de activos:** Documenta máquinas, versiones de PLC, protocolos y fuentes de datos existentes.
+3. **Caso de negocio:** Cuantifica el ROI potencial (reducción de paros, merma, consumo energético).
+
+Entregables: Matriz de oportunidades, casos de uso priorizados y alineación ejecutiva.
+
+## Fase 2 — Diseñar
+
+1. **Arquitectura de referencia:** Define el flujo de datos desde campo hasta analítica (pasarelas OT, MQTT, historiadores, nube).
+2. **Modelo de datos:** Estandariza nomenclaturas (ISA-95) y esquemas de payload.
+3. **Plan de seguridad:** Segmenta redes, define gestión de identidades y mapea requisitos normativos.
+
+Entregables: Diagramas de arquitectura, diseño de seguridad, roadmap del proyecto.
+
+## Fase 3 — Pilotar
+
+1. **Alcance del piloto:** Selecciona una línea o celda que represente los retos generales.
+2. **Implementación:** Despliega pasarelas edge, integra PLC/HMI y conecta dashboards.
+3. **Bucle de retroalimentación:** Recoge feedback de operadores, ajusta tableros y refina umbrales de alertas.
+
+Entregables: Piloto operando, lecciones aprendidas documentadas y modelo de ROI actualizado.
+
+## Fase 4 — Escalar
+
+1. **Plantillas de despliegue:** Convierte las configuraciones del piloto en plantillas reutilizables (Ansible, Terraform, Docker Compose).
+2. **Capacitación:** Prepara a mantenimiento e ingeniería para soportar la solución.
+3. **Gestión del cambio:** Establece gobierno para nuevas solicitudes de datos y modificaciones.
+
+Entregables: Playbooks de despliegue, materiales de formación, procesos de soporte.
+
+## Fase 5 — Optimizar
+
+1. **Analítica avanzada:** Incorpora machine learning, mantenimiento predictivo o gemelos digitales.
+2. **Integración:** Conecta con ERP/MES/CMMS para circuitos cerrados.
+3. **Mejora continua:** Monitorea KPIs, realiza revisiones trimestrales e itera.
+
+Entregables: Backlog de mejora continua, tableros de KPIs, roadmap de innovación.
+
+## Obstáculos comunes y cómo evitarlos
+
+- **Ignorar al equipo OT:** Involucra a los ingenieros de control desde el principio; protegen la producción.
+- **Subestimar la calidad de datos:** Incorpora validación y limpieza en la tubería.
+- **Descuidar la ciberseguridad:** Trata las pasarelas y endpoints en nube como activos críticos.
+- **Querer abarcarlo todo:** Empieza pequeño, entrega valor y luego expande de forma intencional.
+
+## Caso de éxito
+
+Un fabricante de bebidas siguió este playbook para desplegar IIoT en cuatro plantas. En nueve meses redujo 28% los paros no planificados y disminuyó 12% el consumo energético por unidad, al tiempo que los directivos obtenían visibilidad en tiempo real.
+
+IIoT no es solo un proyecto tecnológico; es una transformación operativa. Con metas claras, ejecución disciplinada y colaboración transversal, construirás programas que perduren.

--- a/src/data/post/jerarquias-topicos-mqtt-fabricas-inteligentes.md
+++ b/src/data/post/jerarquias-topicos-mqtt-fabricas-inteligentes.md
@@ -1,0 +1,75 @@
+---
+publishDate: 2025-04-14T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/jerarquias-topicos-mqtt-fabricas-inteligentes
+title: "Diseñar jerarquías de tópicos MQTT para fábricas inteligentes"
+excerpt: "Estructura los tópicos MQTT para mantener datos organizados, seguros y escalables entre plantas, líneas y aplicaciones."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - mqtt
+  - tópicos
+metadata:
+  canonical: https://eduardovieira.dev/es/jerarquias-topicos-mqtt-fabricas-inteligentes
+---
+
+# Diseñar jerarquías de tópicos MQTT para fábricas inteligentes
+
+Una jerarquía bien pensada convierte a MQTT en la columna vertebral de los datos industriales. Un diseño pobre genera confusión y riesgos de seguridad. Estas son las convenciones que utilizo en despliegues multi-sitio.
+
+## 1. Define un estándar de nombres
+
+El formato que suelo adoptar es:
+
+```
+<region>/<planta>/<area>/<linea>/<activo>/<contexto>
+```
+
+Ejemplo: `na/mx-mty/empaque/linea01/taponadora/proceso/torque`
+
+## 2. Separa dominios de datos
+
+- `proceso` para telemetría y KPIs.
+- `alarmas` para eventos que requieren acción humana.
+- `comandos` para instrucciones de control.
+- `_sys` para salud y diagnósticos.
+
+Mantener dominios separados simplifica el control de acceso y el filtrado.
+
+## 3. Usa comodines con estrategia
+
+- `+` coincide con un nivel; `#` con todos los niveles restantes.
+- Asigna permisos con comodines; por ejemplo, mantenimiento lee `na/+/+/+/+/proceso/#` pero solo escribe en tópicos de comandos específicos.
+
+## 4. Versionado y cambios de esquema
+
+- Incluye `v1`, `v2` en la jerarquía cuando cambia la estructura del payload.
+- Soporta tópicos duales durante la migración para no romper consumidores.
+
+## 5. Consideraciones multilingües
+
+- Usa inglés en los nombres de tópico para mantener consistencia global.
+- Proporciona campos localizados en el payload en lugar de duplicar tópicos.
+
+## 6. Mapa de tópicos de ejemplo
+
+| Tópico | Propósito |
+| --- | --- |
+| `na/mx-mty/empaque/linea01/taponadora/proceso/oee` | Métricas OEE |
+| `na/mx-mty/empaque/linea01/taponadora/alarmas/alto_torque` | Notificaciones de alarma |
+| `na/mx-mty/empaque/linea01/taponadora/comandos/ajustar_velocidad` | Tópico de comando |
+| `na/mx-mty/empaque/linea01/taponadora/_sys/heartbeat` | Latido del gateway |
+
+## 7. Seguridad y gobierno
+
+- Implementa ACL que relacionen roles de usuario con patrones de tópicos.
+- Documenta la propiedad de cada namespace para saber quién mantiene cada segmento.
+- Audita suscripciones y publicaciones con regularidad para detectar anomalías.
+
+## 8. Escalar entre sitios
+
+- Reserva el primer nivel para región o unidad de negocio y evitar colisiones (`na`, `latam`, `emea`).
+- Usa identificadores de línea y activo consistentes entre MES, CMMS y MQTT para facilitar la correlación.
+
+Las jerarquías MQTT son más que nomenclatura: son la base de un ecosistema IIoT gestionable y seguro. Invertir tiempo en diseñarlas bien vuelve cada integración mucho más sencilla.

--- a/src/data/post/lista-verificacion-ciberseguridad-industrial.md
+++ b/src/data/post/lista-verificacion-ciberseguridad-industrial.md
@@ -1,0 +1,72 @@
+---
+publishDate: 2025-04-12T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/lista-verificacion-ciberseguridad-industrial
+title: "Lista de verificación para retroadaptar ciberseguridad industrial"
+excerpt: "Pasos prácticos para endurecer sistemas de automatización existentes sin detener la producción."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - ciberseguridad
+  - industrial
+  - seguridad ot
+metadata:
+  canonical: https://eduardovieira.dev/es/lista-verificacion-ciberseguridad-industrial
+---
+
+# Lista de verificación para retroadaptar ciberseguridad industrial
+
+Muchas plantas operan procesos críticos con PLC y HMI heredados casi sin controles de seguridad. Retroadaptar protecciones sin detener la producción es posible si se aborda de forma metódica. Esta checklist recoge los pasos que sigo en evaluaciones y proyectos de remediación.
+
+## 1. Evalúa el estado actual
+
+- **Topología de red:** Documenta switches, firewalls, accesos remotos y hubs sin gestionar.
+- **Inventario de activos:** Identifica versiones de firmware, contraseñas por defecto y servicios obsoletos.
+- **Modelado de amenazas:** Mapea posibles vectores (USB, VPN, inalámbrico, cadena de suministro).
+
+## 2. Segmenta la red
+
+1. Establece una zona OT dedicada con firewalls que apliquen listas blancas estrictas.
+2. Crea zonas DMZ para historiadores, servidores de parches y herramientas de soporte remoto.
+3. Usa VLAN y ACL para separar líneas de producción o procesos críticos.
+
+## 3. Endurece endpoints
+
+- Deshabilita servicios y puertos no utilizados en PLC, HMI y pasarelas.
+- Cambia credenciales por defecto y aplica políticas de contraseñas robustas.
+- Aplica actualizaciones de firmware y parches siguiendo las guías del proveedor.
+- Añade protección en estaciones de ingeniería (whitelisting de aplicaciones, control de USB).
+
+## 4. Asegura el acceso remoto
+
+- Sustituye credenciales compartidas por cuentas individuales integradas con el directorio de identidades.
+- Implementa MFA y grabación de sesiones para proveedores.
+- Prefiere jump servers con acceso auditado en lugar de VPN directas al entorno OT.
+
+## 5. Monitorea y responde
+
+- Despliega monitoreo pasivo de red (Nozomi, Claroty, Zeek) para detectar anomalías.
+- Configura agregación de logs y alertas por cambios de programa en PLC o escrituras no autorizadas.
+- Define playbooks de respuesta con roles, canales de comunicación y rutas de escalamiento.
+
+## 6. Capacita y gobierna
+
+- Realiza sesiones de concienciación adaptadas a mantenimiento y operadores.
+- Establece procesos de gestión de cambios para actualizaciones de firmware y modificaciones de red.
+- Agenda ejercicios de mesa periódicos para validar la preparación ante incidentes.
+
+## 7. Documenta e itera
+
+- Mantén actualizados los diagramas de arquitectura, inventarios y registros de riesgo.
+- Alinea el programa con estándares como IEC 62443 o NIST 800-82.
+- Revisa controles cada trimestre; las amenazas evolutivas exigen ajustes continuos.
+
+## Prioridades de impacto rápido
+
+1. Elimina acceso directo a Internet desde máquinas OT.
+2. Implementa reglas de firewall que restrinjan protocolos/puertos necesarios.
+3. Obliga MFA en los accesos remotos.
+4. Respalda programas de PLC/HMI de forma segura y prueba la restauración.
+
+La retroadaptación de ciberseguridad es un viaje, pero pasos disciplinados reducen drásticamente el riesgo sin detener la producción. Comienza con visibilidad, refuerza la segmentación y fomenta una cultura donde la seguridad sea parte de la operación diaria.

--- a/src/data/post/mejores-practicas-programacion-plc.md
+++ b/src/data/post/mejores-practicas-programacion-plc.md
@@ -1,0 +1,69 @@
+---
+publishDate: 2025-02-24T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/mejores-practicas-programacion-plc
+title: "Mejores prácticas de programación PLC"
+excerpt: "Checklist para entregar código PLC seguro, mantenible y listo para integrarse con sistemas IIoT modernos."
+image: '~/assets/images/plc-programming.jpg'
+category: Automatización Industrial
+tags:
+  - programación plc
+  - mejores prácticas
+metadata:
+  canonical: https://eduardovieira.dev/es/mejores-practicas-programacion-plc
+---
+
+# Mejores prácticas de programación PLC
+
+Tras cientos de proyectos—desde retrofits hasta plantas greenfield—estas prácticas se volvieron innegociables. Mantienen el código entendible, seguro y preparado para integrarse con analítica moderna.
+
+## 1. Parte de estándares
+
+- Adopta modelos de estado ISA-88/PackML cuando apliquen.
+- Usa guías del fabricante (Siemens SiVArc, Rockwell PlantPAx) como plantillas.
+- Mantén estándares de etiquetado, comentarios y uso de lenguajes.
+
+## 2. Arquitectura modular
+
+- Divide la lógica en módulos reutilizables (fases de equipo, rutinas) con interfaces claras.
+- Crea bloques de función de librería para equipos comunes (motores, válvulas, transportadores).
+- Versiona las librerías y documenta el historial de cambios.
+
+## 3. Seguridad primero
+
+- Separa programas PLC de seguridad o rutinas safety del control estándar.
+- Documenta funciones de seguridad y valídalas en FAT/SAT.
+- Incluye rutinas de estado seguro ante pérdida de comunicación o fallas.
+
+## 4. Diagnóstico y visibilidad
+
+- Expone estados clave, alarmas y contadores para HMI, historiadores y payloads MQTT.
+- Registra intervenciones de operadores y cambios de modo.
+- Proporciona guías de troubleshooting alineadas con la estructura del programa.
+
+## 5. Manejo de datos e integración
+
+- Normaliza unidades y escalado antes de exponer datos a otros sistemas.
+- Usa texto estructurado o bloques de función para recetas y parsing de datos.
+- Implementa buffers o store-and-forward al enviar datos a la nube.
+
+## 6. Pruebas y simulación
+
+- Usa simuladores del fabricante (FactoryTalk Logix Echo, Siemens PLCSIM) antes de desplegar.
+- Crea bancos de prueba para funciones y secuencias.
+- Registra casos de prueba y resultados esperados como parte de la documentación.
+
+## 7. Gestión de cambios
+
+- Controla revisiones en repositorios con mensajes descriptivos.
+- Haz revisiones entre pares para detectar errores lógicos y alinear estándares.
+- Respaldos automáticos del programa PLC y verificación de restauración.
+
+## 8. Mejora continua
+
+- Realiza revisiones post-puesta en marcha para capturar lecciones aprendidas.
+- Capacita al mantenimiento en navegación del código y uso de diagnósticos.
+- Actualiza la documentación cada vez que se incorporan nuevas funciones o cambios de proceso.
+
+Un buen código PLC es más que rungs y bloques: es un proceso disciplinado. Sigue estas prácticas para entregar sistemas en los que confían los operadores y que TI puede integrar sin dolores de cabeza.

--- a/src/data/post/modbus-rtu-vs-tcp-eleccion-transporte.md
+++ b/src/data/post/modbus-rtu-vs-tcp-eleccion-transporte.md
@@ -1,0 +1,67 @@
+---
+publishDate: 2025-04-18T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/modbus-rtu-vs-tcp-eleccion-transporte
+title: "Modbus RTU vs. Modbus TCP: cómo elegir el transporte adecuado"
+excerpt: "Diferencias clave entre Modbus RTU y TCP, y cómo decidir qué protocolo conviene en cada proyecto industrial."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - modbus
+  - rtu
+  - tcp
+metadata:
+  canonical: https://eduardovieira.dev/es/modbus-rtu-vs-tcp-eleccion-transporte
+---
+
+# Modbus RTU vs. Modbus TCP: cómo elegir el transporte adecuado
+
+Modbus sigue siendo uno de los protocolos más versátiles de la industria, pero elegir entre RTU y TCP puede definir el éxito del proyecto. Así evalúo cada opción cuando diseño arquitecturas de datos en planta.
+
+## 1. Capa física y topología
+
+| Aspecto | Modbus RTU | Modbus TCP |
+| --- | --- | --- |
+| Medio | Serial RS-485/RS-232 | Ethernet/IP |
+| Topología | Bus multidrop en cadena | Estrella, anillo, malla |
+| Distancia | Hasta 1.200 m sin repetidores | Hasta 100 m por segmento cobre (más con fibra) |
+| Cableado | Par trenzado blindado | Cat5e/Cat6, fibra |
+
+## 2. Consideraciones de desempeño
+
+- **RTU:** Limitado a velocidades seriales (9,6–115,2 kbps típicos). El sondeo es secuencial; cada nodo extra aumenta el ciclo.
+- **TCP:** Soporta 10/100/1000 Mbps, solicitudes en paralelo y payloads mayores. Ideal para recolección de alta frecuencia.
+
+## 3. Disponibilidad de dispositivos
+
+- Muchos drives, básculas y medidores heredados solo exponen Modbus RTU.
+- PLC y gateways modernos suelen ofrecer ambos; algunos hablan TCP nativamente mientras puentean a RTU internamente.
+
+## 4. Seguridad e integración IT
+
+- **RTU:** Requiere gateways serial-IP para monitoreo remoto; la seguridad se basa en controles físicos y segmentación OT.
+- **TCP:** Se integra más fácil con sistemas IT, VPN y servicios en nube. Soporta TLS cuando se usa con gateways seguros o envoltorios Sparkplug.
+
+## 5. Confiabilidad e inmunidad al ruido
+
+- RTU destaca en ambientes eléctricos ruidosos con blindaje y puesta a tierra correctos.
+- TCP aprovecha detección de errores Ethernet y retransmisión, pero necesita infraestructura robusta para evitar pérdida de paquetes.
+
+## 6. Costo y complejidad
+
+- Las redes RTU son económicas de desplegar, pero complejas al ramificarlas o expandirlas.
+- TCP aprovecha infraestructura Ethernet existente, aunque puede requerir switches gestionados, VLAN y coordinación con IT.
+
+## 7. Marco de decisión
+
+1. **Integración heredada:** Si el equipo solo ofrece RTU, utiliza gateways industriales para puente a TCP/MQTT.
+2. **Requerimientos de velocidad:** Elige TCP para tableros OEE, analítica energética y monitoreo en tiempo real.
+3. **Escalabilidad:** TCP escala mejor al añadir dispositivos o clientes remotos.
+4. **Restricciones ambientales:** RTU es más resistente en distancias largas y ambientes ruidosos donde Ethernet es inviable.
+
+## 8. Enfoques híbridos
+
+Muchos proyectos adoptan un modelo híbrido: mantener RTU en el borde para dispositivos legacy, pero convertir a MQTT Sparkplug B sobre Ethernet para consumo IT. Así se preserva el determinismo OT y se entregan datos estructurados a plataformas analíticas.
+
+Elegir entre Modbus RTU y TCP no se trata de cuál es “mejor”, sino de cuál se alinea con tus restricciones operativas y planes de crecimiento. Usa este marco para decidir con intención y evitar recableados dolorosos más adelante.

--- a/src/data/post/modelo-datos-modbus-bobinas-entradas-discretas.md
+++ b/src/data/post/modelo-datos-modbus-bobinas-entradas-discretas.md
@@ -1,0 +1,79 @@
+---
+publishDate: 2025-03-18T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/modelo-datos-modbus-bobinas-entradas-discretas
+title: "Modelo de datos Modbus: bobinas y entradas discretas"
+excerpt: "Cómo mapear y gestionar bobinas y entradas discretas en Modbus, incluyendo estrategias de antirrebote y diagnósticos."
+image: '~/assets/images/modbus.jpg'
+category: Automatización Industrial
+tags:
+  - modbus
+  - modelo de datos
+metadata:
+  canonical: https://eduardovieira.dev/es/modelo-datos-modbus-bobinas-entradas-discretas
+---
+
+# Modelo de datos Modbus: bobinas y entradas discretas
+
+Las señales digitales son la columna vertebral de la automatización Modbus. Al cablear sensores de seguridad o controlar solenoides, entender el comportamiento de bobinas y entradas discretas evita falsas alarmas y estados inesperados.
+
+## 1. Definiciones
+
+- **Bobinas (0xxxx):** Salidas de un bit que se pueden escribir, normalmente para relés o solenoides.
+- **Entradas discretas (1xxxx):** Valores de un bit solo lectura, enlazados a sensores o enclavamientos.
+
+## 2. Planificación de direcciones
+
+Agrupa señales relacionadas para facilitar el escaneo y el diagnóstico:
+
+| Rango | Uso sugerido |
+| --- | --- |
+| 00001–00016 | Salidas de seguridad (relés de paro, contactores) |
+| 00017–00064 | Comandos de máquina (arranque, paro, jog) |
+| 10001–10032 | Entradas de seguridad (cortinas, interruptores de puerta) |
+| 10033–10100 | Sensores de proceso (niveles, proximidad) |
+
+## 3. Antirrebote y filtrado
+
+- Implementa lógica ladder o filtros en la pasarela para evitar que entradas ruidosas conmuten repetidamente.
+- Usa temporizadores en texto estructurado o promedios móviles para sensores expuestos a vibración.
+- Documenta tiempos de antirrebote para que analítica entienda la temporalidad de eventos.
+
+## 4. Diagnóstico y monitoreo de salud
+
+Supervisa el estado de la red digital:
+
+- Cuenta transiciones por turno para detectar sensores en falla (demasiados cambios).
+- Expone bits de diagnóstico que indiquen cortos o sobrecargas.
+- Publica heartbeats desde circuitos de seguridad para verificar su integridad.
+
+## 5. Ejemplo: lectura y escritura de bobinas en Python
+
+```python
+from pymodbus.client import ModbusTcpClient
+
+client = ModbusTcpClient('192.168.1.50')
+
+# Leer entradas discretas 10001–10016
+inputs = client.read_discrete_inputs(address=0, count=16, unit=1)
+print(inputs.bits)
+
+# Activar la bobina 00005
+client.write_coil(address=4, value=True, unit=1)
+```
+
+## 6. Gestión de alarmas
+
+- Asigna niveles de severidad a cada bobina/entrada e intégralos con tu SCADA/CMMS.
+- Crea máquinas de estados para detectar señales trabadas (por ejemplo, comando de arranque activo demasiado tiempo).
+- Usa tópicos MQTT para difundir transiciones de alarma con marca de tiempo y confirmación del operador.
+
+## 7. Checklist de puesta en marcha
+
+1. Valida el cableado y rotula cada terminal claramente.
+2. Prueba cada bobina/entrada a través del PLC/HMI antes de conectar sistemas superiores.
+3. Registra tiempos de scan base para detectar problemas futuros de desempeño.
+4. Documenta estados seguros para cada bobina en caso de pérdida de comunicación.
+
+Bobinas y entradas discretas son solo un bit, pero sostienen la seguridad y desempeño de la máquina. Diseña, documenta y monitorea con cuidado para mantener la operación estable.

--- a/src/data/post/niveles-qos-mqtt-industria.md
+++ b/src/data/post/niveles-qos-mqtt-industria.md
@@ -1,0 +1,66 @@
+---
+publishDate: 2025-04-16T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/niveles-qos-mqtt-industria
+title: "Niveles QoS de MQTT explicados para IIoT"
+excerpt: "Cuándo usar QoS 0, 1 o 2 en manufactura, con ejemplos que equilibran confiabilidad y desempeño."
+image: '~/assets/images/industrial-automation.jpg'
+category: IIoT
+tags:
+  - mqtt
+  - qos
+metadata:
+  canonical: https://eduardovieira.dev/es/niveles-qos-mqtt-industria
+---
+
+# Niveles QoS de MQTT explicados para IIoT
+
+La Calidad de Servicio (QoS) define cómo MQTT garantiza la entrega de mensajes. Seleccionar el nivel adecuado mantiene tus datos confiables sin saturar redes ni PLC. Así aplico QoS en despliegues productivos.
+
+## QoS 0 — Como máximo una vez
+
+- **Características:** Fire-and-forget; sin acuse de recibo.
+- **Usos:** Telemetría no crítica (sensores ambientales, dashboards que se actualizan cada segundos).
+- **Consejos:** Combínalo con mensajes retenidos para que nuevos suscriptores obtengan el último valor al instante.
+
+## QoS 1 — Al menos una vez
+
+- **Características:** El publicador espera PUBACK; el mensaje puede entregarse más de una vez.
+- **Usos:** Valores de proceso, alarmas, métricas OEE, monitoreo de condición.
+- **Consejos:** Diseña los suscriptores para manejar duplicados de forma idempotente (validando timestamp o secuencias).
+
+## QoS 2 — Exactamente una vez
+
+- **Características:** Handshake de cuatro pasos (PUBREC/PUBREL/PUBCOMP). Máxima confiabilidad con más latencia.
+- **Usos:** Comandos críticos (start/stop), descargas de recetas, actualizaciones transaccionales a MES/ERP.
+- **Consejos:** Úsalo con moderación; demasiado tráfico QoS 2 puede generar cuellos de botella en gateways limitados.
+
+## Arquitectura con QoS mixto
+
+```mermaid
+flowchart LR
+  Sensors[Sensores ambientales] -- QoS0 --> Broker
+  PLC[Gateway / PLC] -- QoS1 --> Broker((Broker MQTT))
+  MES[MES/ERP] -- QoS2 --> Broker
+  Broker --> Dashboard
+  Broker --> CMMS
+```
+
+## Consideraciones de desempeño
+
+- Mide latencia y throughput durante la puesta en marcha.
+- Asegura que los clientes MQTT tengan ventanas inflight acordes al tráfico.
+- Usa sesiones persistentes cuando los clientes se conectan de forma intermitente.
+
+## Manejo de errores y reintentos
+
+- Implementa backoff exponencial para reconexiones.
+- Registra fallos de QoS y monitorea estadísticas del broker para detectar problemas temprano.
+- Configura mensajes Last Will para que los sistemas de monitoreo detecten desconexiones inesperadas.
+
+## Alineación con seguridad
+
+Un QoS alto no reemplaza la seguridad. Complementa tu estrategia con cifrado TLS, ACL y gestión de certificados para proteger los tópicos de comando.
+
+La elección correcta equilibra confiabilidad, latencia y uso de recursos. Asigna a cada tópico el nivel que necesita—ni más ni menos—y tu infraestructura MQTT se mantendrá receptiva y resiliente.

--- a/src/data/post/principios-diseno-mecanico-automatizacion.md
+++ b/src/data/post/principios-diseno-mecanico-automatizacion.md
@@ -1,0 +1,63 @@
+---
+publishDate: 2025-01-10T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/principios-diseno-mecanico-automatizacion
+title: "Principios de diseño mecánico para automatización industrial"
+excerpt: "Cómo la ingeniería mecánica que practiqué define máquinas que se integran con controles modernos e IIoT."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - diseño mecánico
+  - automatización
+metadata:
+  canonical: https://eduardovieira.dev/es/principios-diseno-mecanico-automatizacion
+---
+
+# Principios de diseño mecánico para automatización industrial
+
+Antes de especializarme en automatización e IIoT diseñaba sistemas mecánicos para maquinaria a medida. Esa experiencia sigue guiando cada proyecto. Estos son los principios que aplico para que los diseños mecánicos se integren con controles, seguridad y captura de datos.
+
+## 1. Diseña pensando en la estrategia de control
+
+- Define perfiles de movimiento junto al equipo de control para alinear actuadores con los tiempos de scan del PLC.
+- Prevé puntos de montaje para sensores, rutas de cableado y acceso de servicio desde las primeras iteraciones.
+- Usa modelos de estado como PackML para estructurar las secuencias mecánicas.
+
+## 2. Prioriza la mantenibilidad
+
+- Especifica mecanismos de liberación rápida en componentes sujetos a desgaste.
+- Diseña paneles y resguardos que permitan acceso seguro con mínimo tiempo de parada.
+- Incluye indicadores visuales (visores, ventanas de inspección) alineados con la ubicación de sensores.
+
+## 3. Equilibra rigidez y flexibilidad
+
+- Ejecuta análisis FEA en bastidores críticos para evitar vibraciones que degraden la precisión sensorial.
+- Incorpora fijaciones ajustables o herramental modular para cambios de formato.
+- Utiliza componentes estandarizados (rodamientos, cilindros) para simplificar repuestos.
+
+## 4. Integra la seguridad desde el inicio
+
+- Realiza evaluaciones de riesgo (ISO 12100) antes de cerrar layouts.
+- Define la segregación clara de fuentes de energía para bloqueo/etiquetado.
+- Coordina dispositivos de seguridad (barreras, PLCs de seguridad) con la protección mecánica.
+
+## 5. Habilita sensorización inteligente
+
+- Reserva espacio para monitoreo de condición (acelerómetros, cámaras térmicas) aunque se instale más adelante.
+- Añade referencias para calibración de cámaras y futuras mejoras de visión artificial.
+- Ruta cables y canalizaciones para minimizar el ruido eléctrico sobre sensores.
+
+## 6. Documenta a fondo
+
+- Entrega modelos 3D, vistas explotadas y BOM junto a esquemas eléctricos y neumáticos.
+- Anota torque, rutinas de lubricación e intervalos de inspección en los planos.
+- Mantén historial de revisiones accesible para mantenimiento e ingeniería.
+
+## 7. Colabora entre disciplinas
+
+- Realiza revisiones de diseño con operadores, seguridad, control y mantenimiento.
+- Prototipa mecanismos críticos con manufactura rápida para validar ergonomía y ubicación de sensores.
+- Registra lecciones aprendidas tras la puesta en marcha para mejorar diseños futuros.
+
+El diseño mecánico sienta la base de una automatización confiable. Cuando alineas consideraciones mecánicas, eléctricas y de software desde el día uno, construyes máquinas seguras, mantenibles y listas para evoluciones de Industria 4.0.

--- a/src/data/post/que-es-modbus-historia-vigencia.md
+++ b/src/data/post/que-es-modbus-historia-vigencia.md
@@ -1,0 +1,56 @@
+---
+publishDate: 2025-03-12T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/que-es-modbus-historia-vigencia
+title: "¿Qué es Modbus? Historia y vigencia actual"
+excerpt: "Origen de Modbus, por qué sigue presente en planta y cómo modernizar implementaciones sin reemplazar equipos heredados."
+image: '~/assets/images/modbus.jpg'
+category: Automatización Industrial
+tags:
+  - modbus
+  - historia
+metadata:
+  canonical: https://eduardovieira.dev/es/que-es-modbus-historia-vigencia
+---
+
+# ¿Qué es Modbus? Historia y vigencia actual
+
+Modbus impulsa la conectividad industrial desde 1979. A pesar del auge de protocolos modernos, sigue siendo un básico en las plantas. Comprender su historia explica por qué perdura y cómo integrarlo en arquitecturas IIoT actuales.
+
+## 1. Orígenes
+
+- Creado por Modicon (hoy Schneider Electric) para controladores programables.
+- Diseñado como protocolo abierto, lo que permitió la interoperabilidad multivendor desde el inicio.
+- Inicialmente operaba sobre líneas serie RS-232/RS-485 con sondeo maestro/esclavo sencillo.
+
+## 2. Por qué sobrevivió
+
+- **Simplicidad:** Sobrecarga mínima y direccionamiento directo.
+- **Longevidad:** Muchos dispositivos críticos todavía dependen de Modbus RTU.
+- **Ecosistema:** Cientos de proveedores ofrecen sensores, variadores y HMIs compatibles con Modbus.
+
+## 3. Modbus hoy
+
+- **Modbus TCP:** Lleva el protocolo a redes Ethernet, facilitando la integración con sistemas IT.
+- **Gateways:** Traducen Modbus a OPC UA, MQTT u otros protocolos propietarios, conectando equipos antiguos con nuevos.
+- **Integración en la nube:** Gateways perimetrales consultan dispositivos Modbus y publican datos normalizados en plataformas analíticas.
+
+## 4. Desafíos modernos
+
+- Falta de seguridad nativa; la encriptación y autenticación deben añadirse externamente.
+- Modelado de datos limitado; requiere mapear manualmente etiquetas y unidades con significado.
+- El sondeo secuencial puede saturar la red conforme crece el número de dispositivos.
+
+## 5. Estrategias de modernización
+
+- Desplegar gateways industriales que conviertan Modbus a cargas estructuradas (JSON, Sparkplug B).
+- Implementar store-and-forward para manejar conectividad intermitente.
+- Monitorear la salud de la comunicación y alertar por códigos de excepción o timeouts.
+- Planear migraciones graduales: mantener Modbus en el borde mientras se expone la información vía APIs modernas.
+
+## 6. Ejemplo real
+
+En la modernización de una planta de alimentos mantuvimos controladores de temperatura heredados en Modbus RTU, pero añadimos un computador perimetral que publicaba datos en AWS IoT Core. Resultado: visibilidad en tiempo real y alertas predictivas sin tocar lazos de control validados.
+
+Modbus puede tener décadas, pero con la arquitectura correcta sigue entregando valor. Respeta sus limitaciones, refuérzalo con gateways seguros y coexistirá con tus ambiciones de Industria 4.0.

--- a/src/data/post/raspberry-pi-aplicaciones-industriales.md
+++ b/src/data/post/raspberry-pi-aplicaciones-industriales.md
@@ -1,0 +1,69 @@
+---
+publishDate: 2025-03-05T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/raspberry-pi-aplicaciones-industriales
+title: "Raspberry Pi en aplicaciones industriales"
+excerpt: "Casos prácticos donde Raspberry Pi complementa a los PLC, junto con consideraciones de diseño para confiabilidad y seguridad."
+image: '~/assets/images/raspberry-pi.jpg'
+category: IIoT
+tags:
+  - raspberry pi
+  - automatización industrial
+metadata:
+  canonical: https://eduardovieira.dev/es/raspberry-pi-aplicaciones-industriales
+---
+
+# Raspberry Pi en aplicaciones industriales
+
+Las placas Raspberry Pi no sustituyen a los PLC, pero son excelentes compañeras. Las uso para extender visibilidad, prototipar rápido e integrar servicios modernos sin tocar sistemas de control validados. Así lo hago.
+
+## 1. Casos de uso comunes
+
+- **Gateways de datos:** Recopilan información de PLC, Modbus o sensores y la publican en MQTT/OPC UA.
+- **Analítica en el borde:** Ejecutan scripts en Python o Node-RED para OEE, control de calidad o inferencia de IA.
+- **Puentes de protocolo:** Traducen entre dispositivos serie heredados y APIs en la nube.
+- **Herramientas de mantenimiento:** Hospedan tableros de diagnóstico, documentación o endpoints VPN.
+
+## 2. Consideraciones de hardware
+
+- Utiliza modelos industriales (Compute Module, Pi 4/5) con gabinetes robustos.
+- Agrega HATs UPS o convertidores DC-DC para manejar entradas de 24 VDC y sortear caídas de energía.
+- Integra aislamiento digital cuando interfases con señales de alto voltaje.
+
+## 3. Stack de software
+
+- Despliega Raspberry Pi OS Lite de 64 bits para un footprint mínimo.
+- Conteneriza aplicaciones con Docker; define stacks Compose para reproducibilidad.
+- Usa Ansible o pipelines GitOps para gestionar configuraciones de la flota.
+
+## 4. Prácticas de confiabilidad
+
+- Almacena código y datos en SSD/NVMe en lugar de tarjetas SD para reducir desgaste.
+- Monitorea temperatura y condiciones de throttling; añade disipadores y ventiladores cuando sea necesario.
+- Habilita temporizadores watchdog para reiniciar automáticamente ante bloqueos.
+- Implementa colas store-and-forward para caídas de red.
+
+## 5. Seguridad
+
+- Endurece el acceso SSH, deshabilita cuentas por defecto y fuerza autenticación con llaves.
+- Segmenta las redes; usa VLANs y firewalls para evitar movimientos laterales.
+- Aplica actualizaciones automáticas de seguridad durante ventanas de mantenimiento.
+- Encripta datos sensibles y rota certificados con regularidad.
+
+## 6. Integración con PLCs
+
+- Comunícate vía OPC UA, Modbus, drivers Ethernet/IP o APIs del proveedor.
+- Respeta los tiempos de scan del PLC; evita el sondeo excesivo e implementa caché.
+- Documenta los permisos de escritura y aplica acceso basado en roles para evitar control no autorizado.
+
+## 7. Cumplimiento y validación
+
+- Valida las soluciones con Pi igual que cualquier componente de automatización: FAT/SAT, documentación de pruebas e inclusión en gestión de cambios.
+- Usa gabinetes con certificaciones CE/UL cuando lo requieran los estándares de planta.
+
+## 8. Caso de referencia
+
+En una planta de bebidas desplegamos gateways Pi junto a PLC CompactLogix para transmitir métricas de producción a Power BI. Al descargar los reportes en la Pi evitamos costosas actualizaciones de PLC y logramos un retorno en menos de dos meses.
+
+Cuando se diseñan responsablemente, las plataformas Raspberry Pi desbloquean conectividad y analítica modernas mientras los PLC se enfocan en el control en tiempo real.

--- a/src/data/post/seguridad-implementaciones-modbus.md
+++ b/src/data/post/seguridad-implementaciones-modbus.md
@@ -1,0 +1,61 @@
+---
+publishDate: 2025-04-26T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/seguridad-implementaciones-modbus
+title: "Asegurar despliegues Modbus"
+excerpt: "Buenas prácticas para proteger redes Modbus: segmentación, cifrado, monitoreo y respuesta a incidentes."
+image: '~/assets/images/modbus.jpg'
+category: Automatización Industrial
+tags:
+  - modbus
+  - ciberseguridad
+metadata:
+  canonical: https://eduardovieira.dev/es/seguridad-implementaciones-modbus
+---
+
+# Asegurar despliegues Modbus
+
+Modbus nació antes de que la ciberseguridad fuera prioridad, pero aún gobierna millones de dispositivos. Proteger estos entornos exige defensas en capas que respeten las limitaciones operativas. Así lo abordo.
+
+## 1. Segmenta y contiene
+
+- Ubica los dispositivos Modbus en VLAN OT dedicadas o segmentos físicos independientes.
+- Usa firewalls industriales para filtrar protocolos y limitar conexiones.
+- Crea zonas DMZ para pasarelas que conectan Modbus con redes corporativas.
+
+## 2. Controla el acceso
+
+- Deshabilita códigos de función que no se utilicen (por ejemplo, bloquea escrituras si solo necesitas lecturas).
+- Implementa control de acceso basado en roles en las pasarelas; solo cuentas autorizadas pueden escribir.
+- Sustituye credenciales compartidas por logins individuales vinculados a un proveedor de identidades.
+
+## 3. Cifra cuando sea posible
+
+- Modbus carece de cifrado nativo, pero puedes encapsular tráfico en túneles seguros (VPN TLS, IPsec).
+- Prefiere MQTT Sparkplug B u OPC UA para datos que salen de OT, dejando Modbus solo en el borde.
+- Emplea jump hosts seguros para soporte remoto, con MFA y registro de sesiones.
+
+## 4. Monitorea de forma continua
+
+- Despliega monitoreo pasivo para detectar anomalías (códigos inesperados, tormentas de broadcast).
+- Registra todas las escrituras y cambios de configuración con hora e ID del operador.
+- Define umbrales para fallas de comunicación; errores de CRC repetidos pueden indicar manipulación o ruido.
+
+## 5. Endurece los dispositivos
+
+- Actualiza firmware para corregir vulnerabilidades conocidas.
+- Deshabilita puertos de programación o protégelos con llaves cuando no se utilicen.
+- Implementa whitelisting en equipos perimetrales para evitar software no autorizado.
+
+## 6. Plan de respuesta a incidentes
+
+- Define procedimientos para aislar dispositivos comprometidos sin comprometer la seguridad de la producción.
+- Mantén respaldos offline de configuraciones de PLC/RTU.
+- Realiza ejercicios de mesa con equipos OT e IT para practicar los pasos de respuesta.
+
+## 7. Coordinación con proveedores
+
+Colabora con los OEM para conocer su roadmap de seguridad. Solicita divulgación de vulnerabilidades, tiempos de parcheo y guías de endurecimiento.
+
+Modbus seguirá en nuestras plantas por años. Con segmentación, control estricto de acceso, túneles seguros y monitoreo constante, podrás proteger estas redes heredadas sin sacrificar disponibilidad.

--- a/src/data/post/tecnicas-programacion-plc-hibrida.md
+++ b/src/data/post/tecnicas-programacion-plc-hibrida.md
@@ -1,0 +1,93 @@
+---
+publishDate: 2025-01-27T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/tecnicas-programacion-plc-hibrida
+title: "Técnicas de programación híbrida para PLC"
+excerpt: "Combina ladder, texto estructurado y bloques de función para crear programas mantenibles que satisfacen a operaciones y TI."
+image: '~/assets/images/plc-programming.jpg'
+category: Automatización Industrial
+tags:
+  - programación plc
+  - ladder logic
+  - texto estructurado
+metadata:
+  canonical: https://eduardovieira.dev/es/tecnicas-programacion-plc-hibrida
+---
+
+# Técnicas de programación híbrida para PLC
+
+Los proyectos modernos se benefician de combinar lenguajes estratégicamente. Ladder sigue siendo intuitivo para operadores, mientras que el texto estructurado y los bloques de función aportan modularidad e integración. Así los mezclo para entregar programas de PLC mantenibles.
+
+## 1. Define límites de lenguaje
+
+- **Ladder (LD):** Interlocks, cadenas de seguridad y secuencias orientadas al operador.
+- **Function Block Diagram (FBD):** Algoritmos reutilizables (PID, control de motores, modelos PackML).
+- **Structured Text (ST):** Manejo de datos, gestión de recetas, parsers de protocolos y rutinas matemáticas.
+
+Documenta explícitamente qué dominio cubre cada lenguaje para evitar ambigüedades cuando colaboran varios equipos.
+
+## 2. Plano de arquitectura
+
+```mermaid
+flowchart TD
+  Inputs[Entradas digitales/analógicas] --> LD[Capa Ladder]
+  LD --> FBD[Bloques de función]
+  FBD --> ST[Servicios en texto estructurado]
+  ST --> HMI[HMI/SCADA]
+  ST --> Cloud[MQTT / Bases de datos]
+```
+
+- Ladder controla los estados deterministas de la máquina.
+- Los bloques de función encapsulan módulos de equipo.
+- El texto estructurado gestiona el intercambio de datos y los ganchos de analítica.
+
+## 3. Ejemplo: recetas en ST que alimentan secuencias ladder
+
+```pascal
+TYPE Recipe_t :
+STRUCT
+    Temperature : REAL;
+    ConveyorSpeed : REAL;
+    TargetCount : DINT;
+END_STRUCT
+END_TYPE
+
+VAR_GLOBAL
+    CurrentRecipe : Recipe_t;
+    StartSequence : BOOL;
+END_VAR
+
+IF NewRecipeAvailable THEN
+    CurrentRecipe := RecipeBuffer;
+    StartSequence := TRUE;
+END_IF;
+```
+
+El ladder monitorea `StartSequence` para disparar interlocks y secuencias, mientras que el texto estructurado se encarga de parsear y validar datos.
+
+## 4. Estrategia de diagnóstico
+
+- Usa ST para publicar payloads JSON (`MQTT`, `REST`) que expongan estados hacia sistemas IT.
+- Añade rungs dedicados a bits de salud y señales de latido.
+- Implementa bloques de función que capturen métricas de ejecución (tiempo de ciclo, códigos de error) para historiadores.
+
+## 5. Control de versiones y colaboración
+
+- Exporta proyectos como PLCopen XML o fuentes del fabricante para almacenarlos en Git.
+- Establece revisiones conjuntas entre ingenieros de control y especialistas OT/IT.
+- Automatiza linters con PLC Checker u otras herramientas del proveedor.
+
+## 6. Formación para operadores y mantenimiento
+
+- Documenta qué segmentos corresponden a ladder y cuáles a texto estructurado; incluye guías rápidas.
+- Construye proyectos simulados para que los técnicos prueben cambios sin riesgo.
+- Utiliza comentarios bilingües y nomenclaturas consistentes cuando trabajas con equipos multilingües.
+
+## 7. Beneficios logrados
+
+- Gestión de cambios más ágil porque TI puede ajustar rutinas de datos sin tocar la lógica principal.
+- Diagnósticos enriquecidos gracias a datos publicados hacia MES/BI.
+- Los operadores mantienen confianza al ver que las secuencias principales siguen en ladder.
+
+Al combinar los lenguajes de PLC con intención, la automatización se convierte en una plataforma colaborativa donde control, TI y analítica iteran con seguridad sin sacrificar la fiabilidad de la máquina.

--- a/src/data/post/tendencias-automatizacion-industrial-2025.md
+++ b/src/data/post/tendencias-automatizacion-industrial-2025.md
@@ -1,0 +1,51 @@
+---
+publishDate: 2025-06-05T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/tendencias-automatizacion-industrial-2025
+title: "Las 5 principales tendencias de automatización industrial en 2025"
+excerpt: "Tecnologías que ya están generando resultados en planta en 2025: de la convergencia OT/IT al mantenimiento asistido por IA."
+image: '~/assets/images/industrial-automation.jpg'
+category: Automatización Industrial
+tags:
+  - tendencias
+  - industria 4.0
+metadata:
+  canonical: https://eduardovieira.dev/es/tendencias-automatizacion-industrial-2025
+---
+
+# Las 5 principales tendencias de automatización industrial en 2025
+
+Cada año aparecen nuevas palabras de moda, pero pocas entregan un retorno medible. Estas son las tendencias que hoy están impulsando cambios reales en 2025, basadas en los proyectos que acompaño con mis clientes.
+
+## 1. Tuberías de datos del borde a la nube como estándar
+
+- Los fabricantes adoptan arquitecturas MQTT/Sparkplug para entregar datos estructurados y con contexto a las plataformas analíticas.
+- Los gateways perimetrales alojan paneles locales y almacenan datos durante caídas de red, asegurando la resiliencia.
+
+## 2. Mantenimiento asistido por IA más allá de los pilotos
+
+- Las herramientas de monitoreo de condición con aprendizaje automático ya están integradas en los flujos de mantenimiento, no solo en pruebas de concepto.
+- Los técnicos reciben acciones recomendadas en el CMMS, reduciendo el tiempo de diagnóstico.
+
+## 3. Ciberseguridad desde el diseño
+
+- Los programas alineados con IEC 62443 se vuelven obligatorios para OEMs e integradores.
+- Las plantas invierten en segmentación de red, acceso remoto de confianza cero y detección de amenazas en tiempo real.
+
+## 4. Arquitecturas de automatización modulares
+
+- Los diseños estandarizados PackML y los equipos modulares permiten reconfigurar líneas rápidamente.
+- Los conceptos plug-and-produce con OPC UA y MQTT aceleran la puesta en marcha de nuevos SKU.
+
+## 5. Capacitación de la fuerza laboral y herramientas de colaboración
+
+- La realidad mixta, los gemelos digitales y los flujos guiados ayudan a cerrar brechas de habilidades.
+- La documentación bilingüe y las plataformas de colaboración remota permiten que equipos globales resuelvan problemas en conjunto.
+
+### Bonus: métricas de sostenibilidad embebidas en la automatización
+
+- Los indicadores de energía y desperdicio ahora son de primera clase en tableros e indicadores.
+- Los proyectos de automatización incluyen reportes de carbono junto a las metas de throughput.
+
+Para mantenerse competitivos, combinen estas tendencias con una ejecución disciplinada. Enfóquense en tecnologías que mejoren la confiabilidad, empoderen a los equipos y entreguen resultados de negocio claros.

--- a/src/data/post/thingsboard-aplicaciones-web-personalizadas.md
+++ b/src/data/post/thingsboard-aplicaciones-web-personalizadas.md
@@ -1,0 +1,76 @@
+---
+publishDate: 2025-05-16T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/thingsboard-aplicaciones-web-personalizadas
+title: "Cómo desarrollar aplicaciones web personalizadas sobre ThingsBoard"
+excerpt: "Extiende ThingsBoard con aplicaciones, widgets y APIs a medida para cumplir requisitos únicos de automatización industrial."
+image: '~/assets/images/thingsboard.jpg'
+category: IIoT
+tags:
+  - thingsboard
+  - desarrollo web
+metadata:
+  canonical: https://eduardovieira.dev/es/thingsboard-aplicaciones-web-personalizadas
+---
+
+# Cómo desarrollar aplicaciones web personalizadas sobre ThingsBoard
+
+ThingsBoard ofrece una interfaz robusta desde el primer día, pero muchos proyectos necesitan funcionalidades a medida. Así extiendo ThingsBoard de forma segura sin comprometer la mantenibilidad.
+
+## 1. Decide cuándo extender
+
+- **Flujos personalizados:** por ejemplo, aprobaciones de mantenimiento en varios pasos.
+- **Visualizaciones especializadas:** mapas de calor, modelos 3D o overlays de realidad aumentada.
+- **Puentes de integración:** incrustar funcionalidades MES/ERP directamente en dashboards de ThingsBoard.
+
+Si el requisito cabe en los widgets existentes, configura en lugar de personalizar. Construye solo cuando el ROI sea claro.
+
+## 2. Flujo de trabajo para desarrollar widgets
+
+1. Genera el scaffolding con el SDK de widgets de ThingsBoard.
+2. Desarrolla en un entorno local Angular/TypeScript con recarga en caliente.
+3. Usa las APIs REST para probar fuentes de datos.
+4. Empaqueta los widgets y despliega vía la UI de ThingsBoard o su API REST.
+
+## 3. Fragmento de widget de ejemplo
+
+```typescript
+self.onInit = () => {
+  self.ctx.defaultSubscription.subscribe(data => {
+    self.level = data.data[0].value;
+  });
+};
+
+self.getLevelColor = () => {
+  if (self.level > 80) { return '#ff5f56'; }
+  if (self.level > 50) { return '#ffbd2e'; }
+  return '#27c93f';
+};
+```
+
+## 4. Autenticación y APIs
+
+- Usa la API REST de ThingsBoard para operaciones CRUD sobre activos, telemetría y alarmas.
+- Autentica mediante tokens JWT; renueva los tokens de manera segura en las apps cliente.
+- Respeta los límites de inquilino y las cuotas para no interrumpir a los usuarios de producción.
+
+## 5. Despliegue y CI/CD
+
+- Guarda los bundles de widgets y el código personalizado en Git.
+- Automatiza el despliegue con pipelines CI que llamen a las APIs de ThingsBoard.
+- Versiona los widgets; mantén notas de compatibilidad para dashboards que usen versiones anteriores.
+
+## 6. Seguridad y gobernanza
+
+- Valida la entrada del usuario para prevenir ataques de inyección.
+- Restringe los widgets personalizados a desarrolladores de confianza y revisa el código con frecuencia.
+- Monitorea los registros de auditoría para altas, cambios y eliminaciones de widgets.
+
+## 7. Consideraciones de desempeño
+
+- Optimiza las suscripciones de datos; cancélalas cuando los widgets se destruyan.
+- Cachea cálculos pesados y reutiliza datasets entre widgets cuando sea posible.
+- Prueba el desempeño con volúmenes de datos similares a los de producción.
+
+Extender ThingsBoard con criterio te permite entregar experiencias a medida para los operadores sin dejar de mantener la plataforma soportable. Trata el código personalizado con el mismo rigor que cualquier aplicación en producción.

--- a/src/data/post/thingsboard-monitoreo-tanques-scada.md
+++ b/src/data/post/thingsboard-monitoreo-tanques-scada.md
@@ -1,0 +1,71 @@
+---
+publishDate: 2025-05-09T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/thingsboard-monitoreo-tanques-scada
+title: "Cómo construir un SCADA de monitoreo de tanques con ThingsBoard"
+excerpt: "Enfoque paso a paso para modelar tanques, configurar telemetría y entregar dashboards operativos con ThingsBoard."
+image: '~/assets/images/thingsboard.jpg'
+category: IIoT
+tags:
+  - thingsboard
+  - scada
+metadata:
+  canonical: https://eduardovieira.dev/es/thingsboard-monitoreo-tanques-scada
+---
+
+# Cómo construir un SCADA de monitoreo de tanques con ThingsBoard
+
+Monitorear tanques de almacenamiento requiere instrumentación confiable, dashboards intuitivos y alarmas robustas. Así construyo una solución basada en ThingsBoard que los equipos de operaciones confían.
+
+## 1. Instrumentación y captura de datos
+
+- Conecta transmisores de nivel y sondas de temperatura a PLCs o dispositivos de borde.
+- Publica telemetría en ThingsBoard vía MQTT o HTTP usando payloads JSON:
+
+```json
+{
+  "tank_id": "TK-104",
+  "level_percent": 78.2,
+  "temperature_c": 42.5,
+  "volume_liters": 35000,
+  "timestamp": "2025-05-09T12:45:00Z"
+}
+```
+
+## 2. Jerarquía de activos
+
+- Crea un activo por instalación y define entidades de tanque con atributos (capacidad, tipo de producto, rangos seguros).
+- Guarda contactos de mantenimiento y calendarios de inspección como atributos del lado del servidor.
+
+## 3. Diseño del dashboard
+
+- Combina indicadores de nivel, gráficos de tendencia y tablas de alarmas.
+- Añade planos de planta con overlays que muestren el estado del tanque de un vistazo.
+- Ofrece filtros rápidos (por producto, rango de temperatura) para que los operadores encuentren problemas al instante.
+
+## 4. Configuración de alarmas
+
+- Establece umbrales para niveles altos/bajos, cambios rápidos y desviaciones de temperatura.
+- Configura la escalación: primero notifica a operadores, luego a mantenimiento si no se resuelve.
+- Registra confirmaciones y notas de resolución directamente en ThingsBoard.
+
+## 5. Reportes y analítica
+
+- Usa widgets para calcular el tiempo dentro de rangos óptimos.
+- Exporta telemetría a data lakes para pronósticos y conciliación de inventario.
+- Programa reportes PDF automáticos para el relevo de turno diario.
+
+## 6. Acceso móvil y seguridad
+
+- Habilita dashboards responsivos para tabletas y smartphones usados en planta.
+- Implementa control de acceso basado en roles para que solo personal autorizado confirme alarmas o cambie consignas.
+- Utiliza certificados TLS y SSO para autenticación segura.
+
+## 7. Integración con operaciones
+
+- Envía órdenes de trabajo al CMMS cuando los niveles crucen umbrales críticos.
+- Comparte datos con sistemas ERP para apoyar la planificación de producción.
+- Proporciona APIs para que socios logísticos consulten el estado de inventario de forma segura.
+
+Con una base de instrumentación sólida y una configuración cuidadosa de ThingsBoard, el monitoreo de tanques se vuelve proactivo en lugar de reactivo. Los operadores obtienen visibilidad en tiempo real e insights accionables para mantener la producción fluyendo sin contratiempos.

--- a/src/data/post/thingsboard-plataforma-iiot.md
+++ b/src/data/post/thingsboard-plataforma-iiot.md
@@ -1,0 +1,77 @@
+---
+publishDate: 2025-05-02T00:00:00Z
+author: Eduardo Vieira
+lang: es
+slug: es/thingsboard-plataforma-iiot
+title: "Cómo sacar el máximo provecho de ThingsBoard en IIoT"
+excerpt: "Patrones de configuración, tableros e integraciones que convierten a ThingsBoard en un aliado potente para la manufactura inteligente."
+image: '~/assets/images/thingsboard.jpg'
+category: IIoT
+tags:
+  - thingsboard
+  - plataforma iiot
+metadata:
+  canonical: https://eduardovieira.dev/es/thingsboard-plataforma-iiot
+---
+
+# Cómo sacar el máximo provecho de ThingsBoard en IIoT
+
+ThingsBoard es una plataforma flexible para IIoT industrial, pero el éxito real depende de configurar e integrar con disciplina. Así es como la preparo para entornos productivos.
+
+## 1. Visión de arquitectura
+
+```mermaid
+flowchart LR
+  Edge[Gateways perimetrales] --> TB[Clúster de ThingsBoard]
+  TB --> Dashboards[Dashboards de operaciones]
+  TB --> Alarms[Canales de notificación]
+  TB --> Integrations[ERP / CMMS]
+```
+
+- Despliega ThingsBoard en configuración clusterizada (Kubernetes o Docker Compose con HA) para lograr resiliencia.
+- Usa PostgreSQL + TimescaleDB para almacenamiento de telemetría y Redis para colas.
+
+## 2. Modelado de dispositivos y activos
+
+- Representa plantas, líneas y máquinas con las jerarquías de activos de ThingsBoard.
+- Ingresa telemetría vía conectores MQTT, HTTP u OPC UA.
+- Usa atributos del lado del servidor para guardar metadatos (ubicación, responsable de mantenimiento, versiones de firmware).
+
+## 3. Dashboards que encantan a los operadores
+
+- Crea dashboards por rol: operaciones, mantenimiento, calidad.
+- Combina widgets: gráficos de tendencias, tablas de alarmas, tarjetas KPI, mapas del layout.
+- Añade etiquetas multilingües y conversiones de unidades para equipos internacionales.
+
+## 4. Estrategia de alarmas
+
+- Define reglas de alarma con niveles de severidad y rutas de escalamiento.
+- Integra correo, SMS, MS Teams o Slack mediante rule chains.
+- Cierra alarmas automáticamente cuando se normalizan las condiciones y registra las confirmaciones.
+
+## 5. Rule chains para automatización
+
+- Normaliza payloads, aplica cálculos (OEE, intensidad energética) y enruta datos a sistemas externos.
+- Dispara órdenes de trabajo en el CMMS cuando se exceden ciertos umbrales.
+- Usa nodos de script (JavaScript) para lógica personalizada, pero conserva el código reutilizable en control de versiones.
+
+## 6. Endurecimiento de seguridad
+
+- Refuerza las políticas de expiración y renovación de tokens JWT.
+- Separa credenciales de administradores de tenant y de dispositivos.
+- Habilita auditoría para rastrear cambios de configuración.
+- Emplea proxys inversos con terminación TLS y capacidades WAF.
+
+## 7. Consejos de integración
+
+- Conecta con Power BI, Grafana o data lakes mediante APIs REST o el toolkit de integraciones.
+- Sincroniza jerarquías de activos con ERP/MES para mantener nomenclatura consistente.
+- Exporta dashboards y rule chains a Git para control de versiones.
+
+## 8. Manual operativo
+
+- Monitorea la infraestructura (CPU, memoria, longitud de colas) y configura alertas.
+- Agenda respaldos de PostgreSQL y Redis; prueba restauraciones con regularidad.
+- Capacita a operadores en reconocimiento de alarmas e interpretación de KPIs.
+
+Con una arquitectura y gobernanza cuidadosas, ThingsBoard se convierte en mucho más que un dashboard: es el centro nervioso de tu iniciativa IIoT industrial.

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -24,6 +24,9 @@ export const ui: Record<Lang, Record<string, string>> = {
     terms: 'Terms',
     privacy: 'Privacy Policy',
     language: 'Language',
+    announcement_badge: 'Free',
+    announcement_message: 'Unlock your 1‑hour consultancy—schedule your session today! »',
+    footnote_rights: 'All rights reserved.',
   },
   es: {
     home: 'Inicio',
@@ -39,6 +42,9 @@ export const ui: Record<Lang, Record<string, string>> = {
     terms: 'Términos',
     privacy: 'Privacidad',
     language: 'Idioma',
+    announcement_badge: 'Gratis',
+    announcement_message: '¡Obtén tu consultoría de 1 hora—agenda tu sesión hoy mismo! »',
+    footnote_rights: 'Todos los derechos reservados.',
   },
   pt: {
     home: 'Início',
@@ -54,6 +60,9 @@ export const ui: Record<Lang, Record<string, string>> = {
     terms: 'Termos',
     privacy: 'Privacidade',
     language: 'Idioma',
+    announcement_badge: 'Gratuito',
+    announcement_message: 'Agende sua consultoria de 1 hora—reserve hoje mesmo! »',
+    footnote_rights: 'Todos os direitos reservados.',
   },
 };
 

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,5 +1,6 @@
 import type { Lang } from './ui';
 import { defaultLang, languages } from './ui';
+import { BLOG_BASE, CATEGORY_BASE, TAG_BASE } from '~/utils/permalinks';
 
 function isLocalizablePath(pathname: string): boolean {
   const localizableRoots = [
@@ -13,6 +14,16 @@ function isLocalizablePath(pathname: string): boolean {
     '/terms',
   ];
 
+  if (BLOG_BASE) {
+    localizableRoots.push(`/${BLOG_BASE}`);
+  }
+  if (CATEGORY_BASE) {
+    localizableRoots.push(`/${CATEGORY_BASE}`);
+  }
+  if (TAG_BASE) {
+    localizableRoots.push(`/${TAG_BASE}`);
+  }
+
   if (pathname === '/') return true;
 
   // Strip any trailing slash for comparison
@@ -21,7 +32,10 @@ function isLocalizablePath(pathname: string): boolean {
     localizableRoots.includes(clean) ||
     clean.startsWith('/services/') ||
     clean.startsWith('/landing/') ||
-    clean.startsWith('/homes/')
+    clean.startsWith('/homes/') ||
+    (BLOG_BASE ? clean.startsWith(`/${BLOG_BASE}/`) : false) ||
+    (CATEGORY_BASE ? clean.startsWith(`/${CATEGORY_BASE}/`) : false) ||
+    (TAG_BASE ? clean.startsWith(`/${TAG_BASE}/`) : false)
   );
 }
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -5,7 +5,6 @@ import Footer from '~/components/widgets/Footer.astro';
 import Announcement from '~/components/widgets/Announcement.astro';
 
 import { headerData, footerData } from '~/navigation';
-import { getLangFromUrl } from '~/i18n/utils';
 
 import type { MetaData } from '~/types';
 
@@ -14,11 +13,12 @@ export interface Props {
 }
 
 const { metadata } = Astro.props;
+const footer = footerData(Astro.url);
 ---
 
 <Layout metadata={metadata}>
   <slot name="announcement">
-    <Announcement socialLinks={footerData.socialLinks} />
+    <Announcement socialLinks={footer.socialLinks} />
   </slot>
   <slot name="header">
     <Header {...headerData(Astro.url)} isSticky showRssFeed showToggleTheme />
@@ -27,6 +27,6 @@ const { metadata } = Astro.props;
     <slot />
   </main>
   <slot name="footer">
-    <Footer {...footerData(Astro.url)} />
+    <Footer {...footer} />
   </slot>
 </Layout>

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -2,6 +2,44 @@ import { getPermalink, getBlogPermalink } from './utils/permalinks';
 import { getLangFromUrl, translatePath } from '~/i18n/utils';
 import { t, type Lang } from '~/i18n/ui';
 
+const serviceLinkHrefs = {
+  plcProgramming: getPermalink('/services/plc-programming'),
+  hmiScada: getPermalink('/services/hmi-scada'),
+  webHmi: getPermalink('/services/web-hmi'),
+  iiotCloud: getPermalink('/services/iiot-cloud'),
+  controlPanel: getPermalink('/services/control-panel-design'),
+} as const;
+
+const serviceLinkTexts: Record<Lang, Record<keyof typeof serviceLinkHrefs, string>> = {
+  en: {
+    plcProgramming: 'PLC Programming & Industrial Control',
+    hmiScada: 'HMI & SCADA Development',
+    webHmi: 'Web HMI & Remote Dashboards',
+    iiotCloud: 'IIoT & Cloud Integration',
+    controlPanel: 'Control Panel & Electrical Design',
+  },
+  es: {
+    plcProgramming: 'Programación PLC & Control Industrial',
+    hmiScada: 'Desarrollo de HMI & SCADA',
+    webHmi: 'Web HMI & Dashboards Remotos',
+    iiotCloud: 'IIoT & Integración en la Nube',
+    controlPanel: 'Diseño de Tableros & Control Eléctrico',
+  },
+  pt: {
+    plcProgramming: 'Programação de PLC & Controle Industrial',
+    hmiScada: 'Desenvolvimento de HMI & SCADA',
+    webHmi: 'Web HMI & Painéis Remotos',
+    iiotCloud: 'IIoT & Integração em Nuvem',
+    controlPanel: 'Projeto de Painéis & Elétrica',
+  },
+};
+
+const skillTexts: Record<Lang, string[]> = {
+  en: ['Industrial Automation', 'Edge & Cloud Integration', 'SCADA & OT Data', 'Bilingual Collaboration'],
+  es: ['Automatización Industrial', 'Integración Edge & Nube', 'SCADA & Datos OT', 'Colaboración Bilingüe'],
+  pt: ['Automação Industrial', 'Integração Edge & Nuvem', 'SCADA & Dados OT', 'Colaboração Bilíngue'],
+};
+
 export const headerData = (url?: URL) => {
   const lang = url ? (getLangFromUrl(url) as Lang) : ('en' as Lang);
   return {
@@ -24,7 +62,7 @@ export const headerData = (url?: URL) => {
       },
       {
         text: t(lang, 'blog'),
-        href: getBlogPermalink(),
+        href: translatePath(getBlogPermalink(), lang),
       },
       {
         text: t(lang, 'contact'),
@@ -41,36 +79,33 @@ export const footerData = (url?: URL) => {
     links: [
       {
         title: t(lang, 'services_title'),
-        links: [
-          { text: 'PLC Programming & Industrial Control', href: getPermalink('/services/plc-programming') },
-          { text: 'HMI & SCADA Development', href: getPermalink('/services/hmi-scada') },
-          { text: 'Web HMI & Remote Dashboards', href: getPermalink('/services/web-hmi') },
-          { text: 'IIoT & Cloud Integration', href: getPermalink('/services/iiot-cloud') },
-          { text: 'Control Panel & Electrical Design', href: getPermalink('/services/control-panel-design') },
-        ],
+        links: (Object.entries(serviceLinkHrefs) as Array<
+          [keyof typeof serviceLinkHrefs, (typeof serviceLinkHrefs)[keyof typeof serviceLinkHrefs]]
+        >).map(([key, href]) => ({
+          text: serviceLinkTexts[lang][key],
+          href: translatePath(href, lang),
+        })),
       },
       {
         title: t(lang, 'skills_title'),
-        links: [
-          { text: 'Industrial Automation', href: translatePath(getPermalink('/#skills'), lang) },
-          { text: 'Edge & Cloud Integration', href: translatePath(getPermalink('/#skills'), lang) },
-          { text: 'SCADA & OT Data', href: translatePath(getPermalink('/#skills'), lang) },
-          { text: 'Bilingual Collaboration', href: translatePath(getPermalink('/#skills'), lang) },
-        ],
+        links: skillTexts[lang].map((text) => ({
+          text,
+          href: translatePath(getPermalink('/#skills'), lang),
+        })),
       },
       {
         title: t(lang, 'quick_links_title'),
         links: [
           { text: t(lang, 'about'), href: translatePath(getPermalink('/about'), lang) },
           { text: t(lang, 'portfolio'), href: translatePath(getPermalink('/portfolio'), lang) },
-          { text: t(lang, 'blog'), href: getBlogPermalink() },
+          { text: t(lang, 'blog'), href: translatePath(getBlogPermalink(), lang) },
           { text: t(lang, 'contact'), href: translatePath(getPermalink('/contact'), lang) },
         ],
       },
     ],
     secondaryLinks: [
-      { text: t(lang, 'terms'), href: getPermalink('/terms') },
-      { text: t(lang, 'privacy'), href: getPermalink('/privacy') },
+      { text: t(lang, 'terms'), href: translatePath(getPermalink('/terms'), lang) },
+      { text: t(lang, 'privacy'), href: translatePath(getPermalink('/privacy'), lang) },
     ],
     socialLinks: [
     {
@@ -87,8 +122,6 @@ export const footerData = (url?: URL) => {
       target: '_blank',
     },
     ],
-    footNote: `
-      ${new Date().getFullYear()} Eduardo Vieira. All rights reserved.
-    `,
+    footNote: `${new Date().getFullYear()} Eduardo Vieira. ${t(lang, 'footnote_rights')}`,
   };
 };

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -8,6 +8,7 @@ import Pagination from '~/components/blog/Pagination.astro';
 // import PostTags from "~/components/blog/Tags.astro";
 
 import { blogListRobots, getStaticPathsBlogList } from '~/utils/blog';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export const prerender = true;
 
@@ -17,14 +18,18 @@ export const getStaticPaths = (async ({ paginate }) => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
-const { page } = Astro.props as Props;
+const { page, lang: providedLang } = Astro.props as Props & { lang?: Lang };
+const currentLang: Lang = (providedLang ?? defaultLang) as Lang;
 const currentPage = page.currentPage ?? 1;
 
 // const allCategories = await findCategories();
 // const allTags = await findTags();
 
 const metadata = {
-  title: `Blog${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
+  title:
+    currentLang === 'es'
+      ? `Blog${currentPage > 1 ? ` — Página ${currentPage}` : ''}`
+      : `Blog${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
   robots: {
     index: blogListRobots?.index && currentPage === 1,
     follow: blogListRobots?.follow,
@@ -33,15 +38,31 @@ const metadata = {
     type: 'blog',
   },
 };
+
+const copy = {
+  en: {
+    heading: 'Engineering Insights',
+    subtitle:
+      'Expert insights, tutorials, and industry updates on industrial automation, embedded systems, and mechanical engineering',
+  },
+  es: {
+    heading: 'Ideas de Ingeniería',
+    subtitle:
+      'Ideas, tutoriales y novedades sobre automatización industrial, sistemas embebidos e ingeniería mecánica',
+  },
+  pt: {
+    heading: 'Insights de Engenharia',
+    subtitle:
+      'Conteúdos, tutoriais e novidades sobre automação industrial, sistemas embarcados e engenharia mecânica',
+  },
+} as const;
+
+const strings = copy[currentLang] ?? copy[defaultLang];
 ---
 
 <Layout metadata={metadata}>
   <section class="px-6 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
-    <Headline
-      subtitle="Expert insights, tutorials, and industry updates on industrial automation, embedded systems, and mechanical engineering"
-    >
-      Engineering Insights
-    </Headline>
+    <Headline subtitle={strings.subtitle}>{strings.heading}</Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
     <!--

--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -6,6 +6,7 @@ import Layout from '~/layouts/PageLayout.astro';
 import BlogList from '~/components/blog/List.astro';
 import Headline from '~/components/blog/Headline.astro';
 import Pagination from '~/components/blog/Pagination.astro';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export const prerender = true;
 
@@ -15,22 +16,35 @@ export const getStaticPaths = (async ({ paginate }) => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths> & { category: Record<string, string> };
 
-const { page, category } = Astro.props as Props;
+const { page, category, lang: providedLang } = Astro.props as Props & { lang?: Lang };
+const currentLang: Lang = (providedLang ?? defaultLang) as Lang;
 
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Category '${category.title}' ${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
+  title:
+    currentLang === 'es'
+      ? `Categoría '${category.title}'${currentPage > 1 ? ` — Página ${currentPage}` : ''}`
+      : currentLang === 'pt'
+        ? `Categoria '${category.title}'${currentPage > 1 ? ` — Página ${currentPage}` : ''}`
+        : `Category '${category.title}'${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
   robots: {
     index: blogCategoryRobots?.index,
     follow: blogCategoryRobots?.follow,
   },
 };
+
+const heading =
+  currentLang === 'es'
+    ? `Categoría: ${category.title}`
+    : currentLang === 'pt'
+      ? `Categoria: ${category.title}`
+      : `Category: ${category.title}`;
 ---
 
 <Layout metadata={metadata}>
   <section class="px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
-    <Headline>{category.title}</Headline>
+    <Headline>{heading}</Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>

--- a/src/pages/[...blog]/[tag]/[...page].astro
+++ b/src/pages/[...blog]/[tag]/[...page].astro
@@ -6,6 +6,7 @@ import Layout from '~/layouts/PageLayout.astro';
 import BlogList from '~/components/blog/List.astro';
 import Headline from '~/components/blog/Headline.astro';
 import Pagination from '~/components/blog/Pagination.astro';
+import { defaultLang, type Lang } from '~/i18n/ui';
 
 export const prerender = true;
 
@@ -15,22 +16,35 @@ export const getStaticPaths = (async ({ paginate }) => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
-const { page, tag } = Astro.props as Props;
+const { page, tag, lang: providedLang } = Astro.props as Props & { lang?: Lang };
+const currentLang: Lang = (providedLang ?? defaultLang) as Lang;
 
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Posts by tag '${tag.title}'${currentPage > 1 ? ` — Page ${currentPage} ` : ''}`,
+  title:
+    currentLang === 'es'
+      ? `Entradas por etiqueta '${tag.title}'${currentPage > 1 ? ` — Página ${currentPage}` : ''}`
+      : currentLang === 'pt'
+        ? `Artigos por tag '${tag.title}'${currentPage > 1 ? ` — Página ${currentPage}` : ''}`
+        : `Posts by tag '${tag.title}'${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
   robots: {
     index: blogTagRobots?.index,
     follow: blogTagRobots?.follow,
   },
 };
+
+const heading =
+  currentLang === 'es'
+    ? `Etiqueta: ${tag.title}`
+    : currentLang === 'pt'
+      ? `Tag: ${tag.title}`
+      : `Tag: ${tag.title}`;
 ---
 
 <Layout metadata={metadata}>
   <section class="px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
-    <Headline>Tag: {tag.title}</Headline>
+    <Headline>{heading}</Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -12,67 +12,309 @@ const metadata = { title: 'Sobre mí | Eduardo Vieira' };
 ---
 
 <Layout metadata={metadata}>
+  <!-- Hero Widget ******************* -->
+
   <Hero
     tagline="Sobre mí"
-    image={{ src: '~/assets/images/industrial.jpg', alt: 'Ingeniero de Automatización Industrial' }}
+    image={{ src: '~/assets/images/industrial.jpg', alt: 'Ingeniero de Automatización Industrial con tablero de control' }}
   >
     <Fragment slot="title">
       Eduardo Vieira <br />
-      <span class="text-accent dark:text-white highlight">Ingeniero de Automatización & IIoT</span>
+      <span class="text-accent dark:text-white highlight">Ingeniero de Automatización Industrial e IIoT</span>
     </Fragment>
+
     <Fragment slot="subtitle">
-      Ingeniero Mecánico de formación y de Automatización por pasión. Más de siete años conectando equipos de planta con sistemas empresariales.
+      Ingeniero Mecánico de formación e Ingeniero de Automatización por pasión. Desde hace más de siete años conecto equipos de
+      planta con sistemas empresariales, transformando señales crudas en inteligencia confiable para la toma de decisiones.
     </Fragment>
   </Hero>
 
-  <Stats title="Resumen Profesional" stats={[{ title: 'Años integrando OT & IT', amount: '7+' }, { title: 'Upwork Job Success', amount: '100%' }, { title: 'Líneas mejoradas', amount: '30+' }]} />
+  <!-- Stats Widget ****************** -->
+
+  <Stats
+    title="Resumen profesional"
+    stats={[
+      { title: 'Años integrando OT & IT', amount: '7+' },
+      { title: 'Job Success en Upwork', amount: '100%' },
+      { title: 'Líneas de producción optimizadas', amount: '30+' },
+    ]}
+  />
+
+  <!-- Content Widget **************** -->
 
   <Content
     isReversed
     tagline="Trayectoria"
     title="De sistemas mecánicos a fábricas conectadas"
-    items=[
-      { title: 'Bases mecánicas', description: 'Diseño y programación de maquinaria a medida.' },
-      { title: 'Automatización', description: 'PLC, SCADA y optimización de control.' },
-      { title: 'Especialización IIoT', description: 'Pipelines seguros a la nube para visibilidad en tiempo real.' },
-    ]
-    image={{ src: 'https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=2070&q=80', alt: 'Ingeniero' }}
+    items={[
+      {
+        title: 'Bases mecánicas sólidas',
+        description:
+          'Comencé diseñando y programando maquinaria a medida, entendiendo procesos físicos, seguridad y necesidades de los operadores.',
+      },
+      {
+        title: 'Recorrido en automatización industrial',
+        description:
+          'Expandí mi trabajo a programación PLC, desarrollo SCADA y optimización de estrategias de control para industrias discretas y de procesos.',
+      },
+      {
+        title: 'Especialización en IIoT',
+        description:
+          'Hoy diseño pipelines de datos seguros que llevan la información OT a la nube para visibilidad en tiempo real y analítica.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Ingeniero revisando equipamiento de automatización industrial',
+    }}
   >
     <Fragment slot="content">
-      <p>Construyo el flujo de datos completo desde el PLC hasta la nube, con documentación y entrenamiento.</p>
+      <p>
+        Mi carrera comenzó en el piso de planta diseñando sistemas mecánicos y desarrollando lógica PLC para maquinaria a medida.
+        Esa experiencia me enseñó de primera mano cómo operan los equipos de producción, dónde aparecen las paradas y qué se
+        necesita para entregar soluciones de control confiables.
+      </p>
+      <br />
+      <p>
+        A medida que la Industria 4.0 se aceleró, enfoqué mi trabajo en el Internet Industrial de las Cosas. Construyo la cadena
+        completa de datos: controladores, dispositivos edge, brokers MQTT y plataformas cloud para que las organizaciones
+        monitoreen operaciones, reduzcan tiempos muertos y tomen decisiones informadas.
+      </p>
+      <br />
+      <p>
+        Me desempeño cómodamente en entornos multi-plataforma. Siemens, Allen-Bradley, Mitsubishi, ABB o CODESYS: selecciono la
+        herramienta adecuada, documento cada paso y entrego sistemas que tu equipo puede mantener sin sobresaltos.
+      </p>
     </Fragment>
   </Content>
 
+  <!-- Content Widget **************** -->
+
+  <Content
+    isAfterContent
+    tagline="Colaboración"
+    title="Un socio confiable para equipos globales"
+    items={[
+      {
+        title: '100% Job Success',
+        description:
+          'Historial probado con clientes internacionales que confían en mí para proyectos críticos y soporte continuo.',
+      },
+      {
+        title: 'Comunicación bilingüe',
+        description:
+          'Español nativo e inglés fluido para alinear a equipos de ingeniería, operaciones y liderazgo en toda América.',
+      },
+      {
+        title: 'Entrega remota primero',
+        description:
+          'Experiencia trabajando en múltiples husos horarios con documentación clara, actualizaciones proactivas y accesos remotos seguros.',
+      },
+    ]}
+    image={{ src: '~/assets/images/plc.jpg', alt: 'Equipo de automatización colaborando' }}
+  >
+    <Fragment slot="content">
+      <p>
+        Mis clientes valoran a un socio capaz de mantener la visión general sin perder detalle. Coordino stakeholders mecánicos,
+        eléctricos e IT, traduciendo requerimientos en una hoja de ruta cohesionada y comunicando avances en cada hito.
+      </p>
+      <br />
+      <p>
+        Cada proyecto concluye con documentación estructurada, capacitación para operadores y opciones de soporte adaptadas a tus
+        capacidades internas, garantizando que la solución siga entregando valor después de la puesta en marcha.
+      </p>
+    </Fragment>
+  </Content>
+
+  <!-- Features3 Widget ************** -->
+
   <Features3
     title="Identidad"
-    subtitle="Lo que define mi enfoque"
+    subtitle="Los principios que guían mi enfoque de automatización e IIoT"
     columns={3}
-    isBeforeContent={true}
-    items=[
-      { title: 'Puente OT & IT', description: 'Traduzco entre control, IT y liderazgo.', icon: 'tabler:arrows-left-right' },
-      { title: 'Propiedad de extremo a extremo', description: 'Desde lógica PLC hasta dashboards en la nube.', icon: 'tabler:building-factory-2' },
-      { title: 'Datos accionables', description: 'KPIs y decisiones informadas.', icon: 'tabler:chart-dots-2' },
-    ]
+    isBeforeContent
+    items={[
+      {
+        title: 'Puente entre OT e IT',
+        description:
+          'Traduzco entre ingenieros de control, equipos IT y liderazgo para alinear objetivos, riesgos y métricas de éxito.',
+        icon: 'tabler:arrows-left-right',
+      },
+      {
+        title: 'Propiedad end-to-end',
+        description:
+          'Desde lógica PLC y validación de seguridad hasta gateways edge y dashboards en la nube, cubro todo el ciclo de vida.',
+        icon: 'tabler:building-factory-2',
+      },
+      {
+        title: 'Manufactura basada en datos',
+        description:
+          'Diseño soluciones que convierten datos de máquina en inteligencia accionable para mejorar rendimiento, calidad y disponibilidad.',
+        icon: 'tabler:chart-dots-2',
+      },
+    ]}
   />
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    columns={3}
+    isAfterContent
+    title="Plataformas tecnológicas"
+    subtitle="La experiencia multi-vendor me permite entregar la mejor solución para cada entorno"
+    items={[
+      {
+        title: 'Ecosistemas PLC',
+        description:
+          'Siemens TIA Portal, Allen-Bradley Studio 5000, Mitsubishi GX Works, ABB y CODESYS con Ladder, Structured Text y FBD.',
+        icon: 'tabler:cpu',
+      },
+      {
+        title: 'SCADA y visualización',
+        description:
+          'Ignition, ThingsBoard, FUXA, Node-RED, Siemens WinCC, PanelView y Weintek para operadores y ejecutivos.',
+        icon: 'tabler:device-desktop-analytics',
+      },
+      {
+        title: 'IIoT y cloud',
+        description:
+          'MQTT, Sparkplug B, AWS IoT, Azure IoT, Google Cloud, PCs industriales y Python para analítica e integraciones.',
+        icon: 'tabler:cloud-computing',
+      },
+      {
+        title: 'Edge y networking',
+        description:
+          'PCs industriales, Raspberry Pi, VPN seguras, Modbus, OPC UA y Ethernet/IP diseñados para máxima disponibilidad.',
+        icon: 'tabler:topology-star-3',
+      },
+      {
+        title: 'Diseño eléctrico y tableros',
+        description:
+          'AutoCAD Electrical, UL 508A, selección de componentes, esquemas y listas de materiales listas para fabricación.',
+        icon: 'tabler:tool',
+      },
+      {
+        title: 'Software y scripting',
+        description:
+          'Automatizaciones en Python, orquestación con Node-RED y documentación estructurada para mantener equipos alineados.',
+        icon: 'tabler:code',
+      },
+    ]}
+    image={{ src: '~/assets/images/plc.jpg', alt: 'Equipamiento PLC y automatización' }}
+  />
+
+  <!-- Steps2 Widget ****************** -->
+
+  <Steps2
+    title="Principios rectores"
+    subtitle="Valores que aseguran impacto sostenible en cada proyecto"
+    items={[
+      {
+        title: 'Claridad y comunicación',
+        description:
+          'Planificación transparente, checkpoints semanales y documentación visual mantienen alineados a equipos distribuidos.',
+      },
+      {
+        title: 'Confiabilidad ante todo',
+        description:
+          'Los sistemas se construyen con componentes industriales, programación defensiva y mejores prácticas de ciberseguridad.',
+      },
+      {
+        title: 'Mejora continua',
+        description:
+          'Busco oportunidades para mejorar rendimiento, ampliar funcionalidades y preparar tus operaciones para el futuro.',
+      },
+    ]}
+  />
+
+  <!-- Steps2 Widget ****************** -->
+
+  <Steps2
+    title="Logros recientes"
+    subtitle="Cómo ayudo a los fabricantes a modernizarse y escalar"
+    isReversed
+    callToAction={{
+      text: 'Ver portafolio',
+      href: '/es/portfolio',
+    }}
+    items={[
+      {
+        title: 'Gateway MQTT de PLC a la nube',
+        description:
+          'Diseñé un gateway edge que publica datos de proceso desde PLC Mitsubishi hacia AWS IoT, habilitando visibilidad y alertas remotas.',
+        icon: 'tabler:cloud-upload',
+      },
+      {
+        title: 'Actualización de seguridad para línea de empaque',
+        description:
+          'Implementé lógica de PLC de seguridad Mitsubishi, circuitos de paro de emergencia y diagnósticos para cumplir normativas multi-zona.',
+        icon: 'tabler:shield-check',
+      },
+      {
+        title: 'Modernización SCADA',
+        description:
+          'Reemplacé pantallas HMI legadas por interfaces en Ignition y ThingsBoard, brindando control intuitivo y KPIs accionables.',
+        icon: 'tabler:layout-dashboard',
+      },
+    ]}
+  />
+
+  <!-- Features2 Widget ************** -->
 
   <Features2
-    title="Tecnologías"
-    tagline="Skills"
+    title="Capacidades en un vistazo"
+    tagline="Habilidades"
     columns={4}
-    items=[
-      { title: 'Automatización Industrial', description: 'PLC, motion y seguridad.' },
-      { title: 'SCADA & HMIs', description: 'Interfaces intuitivas y alarmas.' },
-      { title: 'IIoT & Datos', description: 'MQTT, Sparkplug B, AWS/Azure/GCP.' },
-      { title: 'Diseño Eléctrico', description: 'Planos, layout y BOM.' },
-    ]
+    items={[
+      {
+        title: 'Automatización industrial',
+        description: 'Programación PLC, control de movimiento e instrumentación de seguridad para procesos y discretos.',
+      },
+      {
+        title: 'SCADA y HMIs',
+        description: 'Interfaces orientadas al operador, dashboards contextuales y estrategias de alarmas efectivas.',
+      },
+      {
+        title: 'IIoT e integración de datos',
+        description: 'MQTT, Sparkplug B y servicios cloud que llevan datos OT a analítica empresarial y sistemas MES.',
+      },
+      {
+        title: 'Diseño eléctrico',
+        description: 'Esquemas de tableros, layout y listas de materiales conforme a estándares industriales.',
+      },
+    ]}
   />
+
+  <!-- Testimonials Widget *********** -->
 
   <Testimonials
-    title="Testimonios"
-    subtitle="Opiniones de equipos de manufactura"
-    testimonials={[{ testimonial: 'Excelente trabajo de IIoT y MQTT.', name: 'Cliente de Control de Procesos', job: 'Gateway PLC a Nube' }]}
+    title="Testimonios de clientes"
+    subtitle="Palabras de líderes de ingeniería que confían en mi trabajo"
+    testimonials={[
+      {
+        testimonial:
+          'Eduardo arquitectó nuestro despliegue IIoT, desde la lógica PLC hasta dashboards en Azure. Su atención al detalle y comunicación disciplinada mantuvieron el proyecto en tiempo en tres plantas.',
+        name: 'Gerente de Automatización',
+        job: 'Fabricante global de alimentos',
+      },
+      {
+        testimonial:
+          'Necesitábamos un socio que hablara español e inglés para unir a los equipos. Eduardo superó expectativas con documentación clara y un lanzamiento SCADA impecable.',
+        name: 'Director de Operaciones',
+        job: 'Planta de packaging en LATAM',
+      },
+      {
+        testimonial:
+          'Cada entregable de Eduardo está listo para producción. Los nuevos tableros y programas PLC incluyeron planos impecables, protocolos de prueba y entrenamiento.',
+        name: 'Líder de Ingeniería',
+        job: 'OEM de equipamiento industrial',
+      },
+    ]}
+    callToAction={{
+      target: '_blank',
+      text: 'Ver mi perfil en Upwork',
+      href: 'https://www.upwork.com/freelancers/~01f21c52fa13e6a195',
+      icon: 'tabler:external-link',
+    }}
   />
 </Layout>
-
-
-

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -4,26 +4,93 @@ import HeroText from '~/components/widgets/HeroText.astro';
 import Features2 from '~/components/widgets/Features2.astro';
 import Content from '~/components/widgets/Content.astro';
 
-const metadata = { title: 'Contacto | Eduardo Vieira - Automatización & IIoT' };
+const metadata = {
+  title: 'Contacto | Eduardo Vieira - Ingeniero de Automatización Industrial e IIoT',
+};
 ---
 
 <Layout metadata={metadata}>
-  <HeroText tagline="Contacto" title="Construyamos el futuro de tu fábrica" subtitle="PLC, SCADA o estrategia IIoT: listo para ayudarte." />
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    tagline="Contacto"
+    title="Construyamos el futuro de tu fábrica"
+    subtitle="Ya sea programación PLC, modernización SCADA o una estrategia IIoT para toda la planta, estoy listo para acompañarte desde el concepto hasta la producción."
+  />
 
   <Content
     isReversed
-    tagline="Primeros pasos"
+    tagline="Cómo iniciamos"
     title="Un proceso claro y colaborativo"
-    items={[{ title: '1. Llamada de descubrimiento', description: 'Alcance y métricas de éxito.' }, { title: '2. Propuesta & Arquitectura', description: 'Entregables, hitos y tecnologías.' }, { title: '3. Entrega & Soporte', description: 'Actualizaciones, documentación y soporte.' }]}
-    image={{ src: 'https://images.unsplash.com/photo-1600880292203-757bb62b4baf?auto=format&fit=crop&w=2070&q=80', alt: 'Consulta de ingeniería' }}
+    items={[
+      {
+        title: '1. Reunión de descubrimiento',
+        description:
+          'Revisamos tus sistemas actuales, puntos de dolor y objetivos para confirmar el alcance y las métricas de éxito.',
+      },
+      {
+        title: '2. Propuesta y arquitectura',
+        description:
+          'Recibes una propuesta detallada con entregables, hitos y tecnologías recomendadas para tu entorno.',
+      },
+      {
+        title: '3. Ejecución y soporte',
+        description:
+          'Desarrollo el trabajo con actualizaciones periódicas, documentación y opciones de soporte continuo.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1600880292203-757bb62b4baf?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Consultoría de ingeniería con planos',
+    }}
   />
+
+  <!-- Features2 Widget ************** -->
 
   <Features2
-    title="Cómo contactarme"
-    subtitle="Alineemos prioridades de automatización e IIoT"
-    items={[{ title: 'Email', description: 'me@eduardovieira.dev', icon: 'tabler:mail' }, { title: 'LinkedIn', description: 'Conectar para proyectos.', icon: 'tabler:brand-linkedin', callToAction: { text: 'Conectar', href: 'https://www.linkedin.com/in/eduardojv/', target: '_blank' } }, { title: 'Upwork', description: 'Ver perfil y feedback.', icon: 'tabler:brand-upwork', callToAction: { text: 'Ver Perfil', href: 'https://www.upwork.com/freelancers/eduardojv', target: '_blank' } } ]}
+    title="Formas de contacto"
+    subtitle="Alineemos tus prioridades de automatización e IIoT."
+    items={[
+      {
+        title: 'Email',
+        description: 'me@eduardovieira.dev',
+        icon: 'tabler:mail',
+      },
+      {
+        title: 'LinkedIn',
+        description: 'Conecta para conversar sobre proyectos y novedades.',
+        icon: 'tabler:brand-linkedin',
+        callToAction: {
+          text: 'Conectar',
+          href: 'https://www.linkedin.com/in/eduardojv/',
+          target: '_blank',
+        },
+      },
+      {
+        title: 'Upwork',
+        description: 'Revisa mi 100% Job Success y comentarios de clientes.',
+        icon: 'tabler:brand-upwork',
+        callToAction: {
+          text: 'Ver perfil',
+          href: 'https://www.upwork.com/freelancers/eduardojv',
+          target: '_blank',
+        },
+      },
+      {
+        title: 'Idiomas',
+        description: 'Español nativo e inglés fluido para una colaboración sin barreras entre equipos.',
+        icon: 'tabler:language',
+      },
+      {
+        title: 'Zonas horarias',
+        description: 'Con base en Argentina (UTC-3) y disponibilidad para horarios de Norteamérica y Europa.',
+        icon: 'tabler:clock',
+      },
+      {
+        title: 'Tiempo de respuesta',
+        description: 'La mayoría de las consultas se responden en menos de un día hábil.',
+        icon: 'tabler:message-circle',
+      },
+    ]}
   />
 </Layout>
-
-
-

--- a/src/pages/es/homes/mobile-app.astro
+++ b/src/pages/es/homes/mobile-app.astro
@@ -1,0 +1,297 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+
+import Header from '~/components/widgets/Header.astro';
+
+import Hero2 from '~/components/widgets/Hero2.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import Content from '~/components/widgets/Content.astro';
+import Testimonials from '~/components/widgets/Testimonials.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import Stats from '~/components/widgets/Stats.astro';
+
+import Button from '~/components/ui/Button.astro';
+import Image from '~/components/common/Image.astro';
+
+const appStoreImg = '~/assets/images/app-store.png';
+const appStoreDownloadLink = 'https://github.com/onwidget/astrowind';
+
+const googlePlayImg = '~/assets/images/google-play.png';
+const googlePlayDownloadLink = 'https://github.com/onwidget/astrowind';
+
+const metadata = {
+  title: 'Demo de App Móvil',
+};
+---
+
+<Layout metadata={metadata}>
+  <Fragment slot="announcement"></Fragment>
+  <Fragment slot="header">
+    <Header
+      position="left"
+      links={[
+        { text: 'Servicios', href: '#' },
+        { text: 'Características', href: '#' },
+        { text: 'Acerca de', href: '#' },
+      ]}
+      actions={[
+        {
+          text: 'Descargar',
+          href: '#download',
+        },
+      ]}
+      isSticky
+      showToggleTheme
+    />
+  </Fragment>
+
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero2
+    tagline="Demo web de app móvil"
+    image={{
+      src: 'https://images.unsplash.com/photo-1535303311164-664fc9ec6532?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=987&q=80',
+      alt: 'Imagen de hero AstroWind',
+    }}
+  >
+    <Fragment slot="title">
+      <span class="text-accent dark:text-white highlight">AstroWind App</span>: <br /> sitios profesionales <span
+        class="hidden xl:inline">en cuestión de minutos</span
+      >
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      <span class="hidden sm:inline">
+        Desata creatividad ilimitada desde la palma de tu mano: tu puerta de entrada al diseño innovador.
+      </span>
+      Descárgala ahora y eleva tus proyectos como nunca antes.
+    </Fragment>
+
+    <div slot="actions" class="flex max-w-sm gap-4">
+      <Button variant="link" href={appStoreDownloadLink}>
+        <Image src={appStoreImg} alt="Botón App Store" width={200} />
+      </Button>
+
+      <Button variant="link" href={googlePlayDownloadLink}>
+        <Image src={googlePlayImg} alt="Botón Google Play" width={200} />
+      </Button>
+    </div>
+  </Hero2>
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    id="features"
+    title="¿Cómo usar nuestra app?"
+    subtitle="¿Cansado de pasar horas creando documentos desde cero? Nuestra app ofrece una solución innovadora. Con una amplia variedad de plantillas profesionales podrás crear diseños increíbles en minutos. Explora nuestras plantillas y comprueba la diferencia."
+    tagline="Guía paso a paso"
+    columns={2}
+    items={[
+      {
+        title: 'Descarga e instala la app',
+        description: `Comienza descargando nuestra app intuitiva desde la tienda de tu dispositivo o desde nuestro sitio oficial.`,
+        icon: 'tabler:square-number-1',
+      },
+      {
+        title: 'Crea tu cuenta',
+        description:
+          'Regístrate con la información necesaria para acceder a todas las funcionalidades disponibles.',
+        icon: 'tabler:square-number-2',
+      },
+      {
+        title: 'Explora las plantillas',
+        description: 'Recorre nuestra colección categorizada de plantillas para encontrar la ideal.',
+        icon: 'tabler:square-number-3',
+      },
+      {
+        title: 'Previsualiza y elige',
+        description: `Visualiza el potencial de cada plantilla y selecciona la que mejor se adapte a tu proyecto.`,
+        icon: 'tabler:square-number-4',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1521517407911-565264e7d82d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
+      alt: 'Imagen colorida',
+    }}
+  />
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    isReversed
+    items={[
+      {
+        title: 'Interfaz intuitiva',
+        description:
+          'Una interfaz fácil de navegar que permite encontrar rápidamente las plantillas adecuadas.',
+        icon: 'tabler:wand',
+      },
+      {
+        title: 'Opciones de personalización',
+        description:
+          'Incluye herramientas básicas para modificar textos, colores, imágenes y otros elementos de cada plantilla.',
+        icon: 'tabler:settings',
+      },
+      {
+        title: 'Componentes listos para usar',
+        description:
+          'Mejora tus diseños con gráficos, íconos y layouts prediseñados, ahorrando tiempo y aumentando el impacto visual.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Modo de vista previa',
+        description: 'Previsualiza cada plantilla antes de comprarla para asegurarte de que sea la indicada.',
+        icon: 'tabler:carousel-horizontal',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1576153192621-7a3be10b356e?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1674&q=80',
+      alt: 'Imagen colorida',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Funciones principales</h3>
+    </Fragment>
+  </Content>
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    isAfterContent
+    items={[
+      {
+        title: 'Acceso sin conexión',
+        description: 'Permite descargar las plantillas adquiridas para usarlas sin conexión.',
+        icon: 'tabler:wifi-off',
+      },
+      {
+        title: 'Almacenamiento seguro en la nube',
+        description:
+          'Ofrece almacenamiento cloud para tus plantillas compradas, asegurando acceso y respaldo desde cualquier lugar.',
+        icon: 'tabler:file-download',
+      },
+      {
+        title: 'Actualizaciones regulares',
+        description: 'Agregamos nuevas plantillas y funciones continuamente para mantener la app fresca y atractiva.',
+        icon: 'tabler:refresh',
+      },
+      {
+        title: 'Lista de favoritos',
+        description: `Crea una lista de deseos con plantillas que te interesen para revisarlas y comprarlas más tarde.`,
+        icon: 'tabler:heart',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1453738773917-9c3eff1db985?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+      alt: 'Imagen vintage',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Otras funciones</h3>
+    </Fragment>
+  </Content>
+
+  <!-- Stats Widget ****************** -->
+
+  <Stats
+    title="Estadísticas de la app"
+    stats={[
+      { amount: '20K', icon: 'tabler:download' },
+      { amount: '18.5K', icon: 'tabler:users' },
+      { amount: '4.7', icon: 'tabler:user-star' },
+    ]}
+  />
+
+  <!-- Testimonials Widget *********** -->
+
+  <Testimonials
+    title="¿Qué opinan nuestros usuarios?"
+    testimonials={[
+      {
+        testimonial: `Explorar y descargar plantillas nunca fue tan sencillo. La interfaz es intuitiva y encontré el diseño perfecto para mi proyecto sin complicaciones. Es una app que empodera a los usuarios.`,
+        name: 'Cary Kennedy',
+        job: 'Directora de cine',
+        image: {
+          src: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+          alt: 'Foto de Cary Kennedy',
+        },
+      },
+      {
+        testimonial: `El proceso de descarga es fluido y la navegación muy cómoda. Poder previsualizar y probar distintos diseños antes de decidirme me ahorró tiempo y garantizó el aspecto ideal para mi sitio.`,
+        name: 'Josh Wilkinson',
+        job: 'Product Manager',
+        image: {
+          src: 'https://images.unsplash.com/flagged/photo-1570612861542-284f4c12e75f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+          alt: 'Foto de Josh Wilkinson',
+        },
+      },
+      {
+        testimonial:
+          'En cuestión de minutos descargué y utilicé una plantilla profesional. El proceso guiado y la interfaz amigable me permitieron crear un sitio con apariencia experta.',
+        name: 'Sidney Hansen',
+        job: 'Decoradora',
+        image: {
+          src: 'https://images.unsplash.com/photo-1512361436605-a484bdb34b5f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+          alt: 'Foto de Sidney Hansen',
+        },
+      },
+    ]}
+    callToAction={{
+      target: '_blank',
+      text: 'Leer más testimonios',
+      href: 'https://github.com/onwidget/astrowind',
+      icon: 'tabler:chevron-right',
+    }}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="¿Aún tienes dudas?"
+    items={[
+      {
+        title: '¿Qué hace esta app?',
+        description:
+          'Ofrece una plataforma para explorar, comprar, descargar y utilizar una amplia variedad de plantillas web para tus proyectos.',
+      },
+      {
+        title: '¿Cómo resuelve mi problema?',
+        description:
+          'Simplifica la búsqueda e implementación de diseños profesionales, ahorrando tiempo y esfuerzo al crear sitios atractivos y funcionales.',
+      },
+      {
+        title: '¿Está disponible para mi dispositivo?',
+        description: `Nuestra app es compatible con múltiples dispositivos y plataformas, ya sea smartphone, tablet o computadora.`,
+      },
+      {
+        title: '¿Qué la diferencia de otras apps?',
+        description:
+          'Su interfaz amigable, la colección extensa de plantillas y la integración fluida del proceso de compra y descarga la vuelven altamente eficiente.',
+      },
+      {
+        title: '¿Tiene algún costo?',
+        description:
+          'La app puede descargarse gratis, pero algunas plantillas premium pueden tener un costo según tus preferencias y necesidades.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    id="download"
+    title="¡Descarga la app hoy mismo!"
+    subtitle="Accede a plantillas impactantes, simplifica tu proceso creativo y eleva tu presencia digital."
+  >
+    <div slot="actions" class="flex max-w-sm gap-4">
+      <Button variant="link" href={appStoreDownloadLink}>
+        <Image src={appStoreImg} alt="Botón App Store" width={200} />
+      </Button>
+
+      <Button variant="link" href={googlePlayDownloadLink}>
+        <Image src={googlePlayImg} alt="Botón Google Play" width={200} />
+      </Button>
+    </div>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/homes/personal.astro
+++ b/src/pages/es/homes/personal.astro
@@ -1,0 +1,400 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+
+import Header from '~/components/widgets/Header.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import Content from '~/components/widgets/Content.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import Testimonials from '~/components/widgets/Testimonials.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
+
+const metadata = {
+  title: 'Demo de página personal',
+};
+---
+
+<Layout metadata={metadata}>
+  <Fragment slot="announcement"></Fragment>
+  <Fragment slot="header">
+    <Header
+      links={[
+        { text: 'Inicio', href: '#' },
+        { text: 'Sobre mí', href: '#about' },
+        { text: 'Currículum', href: '#resume' },
+        { text: 'Portafolio', href: '#portfolio' },
+        { text: 'Blog', href: '#blog' },
+        { text: 'Github', href: 'https://github.com/onwidget' },
+      ]}
+      actions={[
+        {
+          text: 'Contrátame',
+          href: '#',
+        },
+      ]}
+      isSticky
+      showToggleTheme
+    />
+  </Fragment>
+
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero
+    id="hero"
+    title="Sarah Johnson"
+    tagline="Demo web personal"
+    actions={[{ variant: 'primary', text: 'Contrátame', href: '/es/contact#form' }]}
+  >
+    <Fragment slot="subtitle">
+      Soy una diseñadora gráfica apasionada por crear historias visuales. <br /> Con cinco años de experiencia y un título de la Escuela de Diseño de la Universidad de Nueva York, doy vida a marcas y conceptos convirtiéndolos en realidades cautivadoras.
+    </Fragment>
+  </Hero>
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    id="about"
+    columns={3}
+    items={[
+      {
+        icon: 'tabler:brand-dribbble',
+        callToAction: {
+          target: '_blank',
+          text: 'Dribbble',
+          href: '#',
+        },
+      },
+      {
+        icon: 'tabler:brand-behance',
+        callToAction: {
+          target: '_blank',
+          text: 'Behance',
+          href: '#',
+        },
+      },
+      {
+        icon: 'tabler:brand-pinterest',
+        callToAction: {
+          target: '_blank',
+          text: 'Pinterest',
+          href: '#',
+        },
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1491349174775-aaafddd81942?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80',
+      alt: 'Imagen colorida',
+      loading: 'eager',
+    }}
+  >
+    <Fragment slot="content">
+      <h2 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Sobre mí</h2>
+      <p>
+        Bienvenido a mi viaje creativo. Cada proyecto refleja mi compromiso por convertir ideas en experiencias visuales memorables, donde cada píxel es un trazo dentro de un lienzo imaginativo.
+      </p>
+      <br />
+      <p>
+        Encuentro inspiración en el mundo que me rodea: en las páginas de una novela, en los detalles tipográficos y en los colores vibrantes de la naturaleza.
+      </p>
+      <br />
+      <p>Si quieres conocer más de mi trabajo, sígueme en mis redes:</p>
+    </Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    id="resume"
+    title="Experiencia profesional"
+    items={[
+      {
+        title:
+          'Diseñadora Gráfica <br /> <span class="font-normal">ABC Design Studio, Nueva York</span> <br /> <span class="text-sm font-normal">2021 - Presente</span>',
+        description: `Colaboro con clientes para entender objetivos y requerimientos. <br /> Desarrollo soluciones de branding, incluyendo logotipos, paletas de color y guías de marca. <br /> Diseño material de marketing como folletos, pósters y recursos digitales. <br /> Creo interfaces atractivas para sitios web y aplicaciones.`,
+        icon: 'tabler:briefcase',
+      },
+      {
+        title:
+          'Diseñadora Gráfica Junior <br /> <span class="font-normal">XYZ Creative Agency, Los Ángeles</span> <br /> <span class="text-sm font-normal">2018 - 2021</span>',
+        description: `Apoyé a diseñadores senior en la creación de conceptos y piezas visuales. <br /> Contribuí al desarrollo de identidades de marca y material promocional. <br /> Colaboré con el equipo de marketing para asegurar coherencia entre campañas. <br /> Adquirí experiencia práctica en diversos softwares y herramientas de diseño.`,
+        icon: 'tabler:briefcase',
+      },
+    ]}
+    classes={{ container: 'max-w-3xl' }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    id="resume"
+    title="Educación"
+    items={[
+      {
+        title: `Maestría en Diseño Gráfico <br /> <span class="font-normal">NYU School of Design</span> <br /> <span class="text-sm font-normal">2018 - 2020</span>`,
+        icon: 'tabler:school',
+      },
+      {
+        title: `Licenciatura en Diseño Gráfico <br /> <span class="font-normal">NYU School of Design</span> <br /> <span class="text-sm font-normal">2014 - 2018</span>`,
+        icon: 'tabler:school',
+      },
+    ]}
+    classes={{ container: 'max-w-3xl' }}
+  />
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    title="Habilidades"
+    subtitle="Descubre las competencias que me permiten materializar la imaginación a través del diseño."
+    columns={3}
+    defaultIcon="tabler:point-filled"
+    items={[
+      {
+        title: 'Diseño gráfico',
+        description: 'Capacidad para crear piezas visuales impactantes que comunican mensajes con claridad.',
+      },
+      {
+        title: 'Branding e identidad',
+        description: 'Experta en desarrollar identidades coherentes, incluyendo logotipos y guías de marca.',
+      },
+      {
+        title: 'Diseño centrado en el usuario',
+        description: 'Experiencia en interfaces amigables y optimización de experiencias de usuario.',
+      },
+      {
+        title: 'Adobe Creative Suite',
+        description: 'Dominio de Photoshop, Illustrator e InDesign para crear y editar elementos visuales.',
+      },
+      {
+        title: 'Tipografía',
+        description: 'Habilidad para seleccionar y manipular tipografías que potencian la estética del diseño.',
+      },
+      {
+        title: 'Teoría del color',
+        description: 'Uso del color para evocar emociones y lograr armonía visual.',
+      },
+      {
+        title: 'Diseño impreso y digital',
+        description: 'Conocimiento para producir piezas tanto para materiales impresos como para plataformas digitales.',
+      },
+      {
+        title: 'Atención al detalle',
+        description: 'Cuidado extremo para mantener precisión y calidad en cada proyecto.',
+      },
+      {
+        title: 'Adaptabilidad',
+        description: 'Capacidad de adoptar nuevas tendencias, tecnologías y preferencias de clientes rápidamente.',
+      },
+    ]}
+  />
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    id="portfolio"
+    title="Elevando narrativas visuales"
+    subtitle="Embárcate en un recorrido creativo que va más allá de los píxeles y da forma a historias cautivadoras."
+    isReversed
+    items={[
+      {
+        title: 'Descripción:',
+        description:
+          'Desarrollé una identidad integral para la startup Tech Innovators. El objetivo: proyectar una imagen moderna y cercana para clientes corporativos y entusiastas tecnológicos.',
+      },
+      {
+        title: 'Rol:',
+        description:
+          'Lideré el proceso completo de branding, desde la conceptualización hasta la ejecución. Creé un logotipo dinámico, definí una paleta vibrante y diseñé papelería, gráficos web y activos para redes sociales.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1658248165252-71e116af1b34?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=928&q=80',
+      alt: 'Diseño tecnológico',
+    }}
+    callToAction={{
+      target: '_blank',
+      text: 'Ver proyecto',
+      icon: 'tabler:chevron-right',
+      href: '#',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">
+        Proyecto 1: <br /><span class="text-2xl">Identidad para Tech Innovators</span>
+      </h3>
+    </Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    isReversed
+    isAfterContent={true}
+    items={[
+      {
+        title: 'Descripción:',
+        description:
+          'Diseñé un póster llamativo para el festival de arte y música “ArtWave Fusion”, destacando la sinergia entre disciplinas.',
+      },
+      {
+        title: 'Rol:',
+        description: `Traducí el tema creativo del festival en un póster impactante. Utilicé tipografías audaces, colores vibrantes y elementos abstractos que transmiten la fusión entre arte y música.`,
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1619983081563-430f63602796?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80',
+      alt: 'Póster de arte y música',
+    }}
+    callToAction={{
+      target: '_blank',
+      text: 'Ver proyecto',
+      icon: 'tabler:chevron-right',
+      href: '#',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">
+        Proyecto 2: <br /><span class="text-2xl">Póster para festival de arte y música</span>
+      </h3>
+    </Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    isReversed
+    isAfterContent={true}
+    items={[
+      {
+        title: 'Descripción:',
+        description: `Rediseñé la web de e-commerce de la marca sostenible GreenVogue para alinear su presencia digital con su filosofía ecológica y mejorar la experiencia de compra.`,
+      },
+      {
+        title: 'Rol:',
+        description: `Analicé valores y audiencia de la marca para definir la dirección creativa. Creé una interfaz atractiva con navegación intuitiva, destacando materiales sostenibles e integrando un flujo de compra amigable.`,
+      },
+    ]}
+    image={{
+      src: 'https://plus.unsplash.com/premium_photo-1683288295841-782fa47e4770?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=870&q=80',
+      alt: 'E-commerce de moda sostenible',
+    }}
+    callToAction={{
+      target: '_blank',
+      text: 'Ver proyecto',
+      icon: 'tabler:chevron-right',
+      href: '#',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">
+        Proyecto 3: <br /><span class="text-2xl">Rediseño e-commerce para marca de moda</span>
+      </h3>
+    </Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Testimonials Widget *********** -->
+
+  <Testimonials
+    title="Testimonios de clientes"
+    subtitle="Descubre lo que dicen las marcas con las que colaboro."
+    testimonials={[
+      {
+        testimonial: `Transformó nuestro concepto inicial en una pieza visual que alinea a la perfección nuestros objetivos. Su atención al detalle y la capacidad para convertir ideas en historias impactantes superaron nuestras expectativas.`,
+        name: 'Mark Thompson',
+        job: 'Director creativo',
+        image: {
+          src: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80',
+          alt: 'Foto de Mark Thompson',
+        },
+      },
+      {
+        testimonial: `Renovó nuestra identidad con maestría, capturando nuestra esencia en cada elemento. Su dedicación y talento brillan en cada entrega.`,
+        name: 'Emily Martinez',
+        job: 'CEO',
+        image: {
+          src: 'https://images.unsplash.com/photo-1554151228-14d9def656e4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=772&q=80',
+          alt: 'Foto de Emily Martinez',
+        },
+      },
+      {
+        testimonial: `Tiene una habilidad única para comunicar emociones e historias. El logo que creó para nuestra ONG representa la causa y despierta empatía. Su profesionalismo la convierte en una diseñadora excepcional.`,
+        name: 'Laura Simmons',
+        job: 'Fundadora de ONG',
+        image: {
+          src: 'https://images.unsplash.com/photo-1554727242-741c14fa561c?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80',
+          alt: 'Foto de Laura Simmons',
+        },
+      },
+      {
+        testimonial: `Confiamos a Sarah la renovación de la interfaz de nuestro sitio y el resultado fue sobresaliente. Su intuición elevó la experiencia de usuario, aumentando significativamente el engagement.`,
+        name: 'Alex Foster',
+        job: 'Director de servicios web',
+        image: {
+          src: 'https://images.unsplash.com/photo-1599566150163-29194dcaad36?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80',
+          alt: 'Foto de Alex Foster',
+        },
+      },
+      {
+        testimonial: `Tomó nuestra visión y la elevó más allá de lo imaginado. Capturó la esencia de nuestra marca y la tradujo en diseño con resultados admirables.`,
+        name: 'Jessica Collins',
+        job: 'Product Manager',
+        image: {
+          src: 'https://images.unsplash.com/photo-1548142813-c348350df52b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=778&q=80',
+          alt: 'Foto de Jessica Collins',
+        },
+      },
+      {
+        testimonial: `Su capacidad para transformar conceptos en visuales cautivadores es extraordinaria. El póster que creó para nuestro festival capturó a la perfección su esencia.`,
+        name: 'Michael Carter',
+        job: 'Coordinador de eventos',
+        image: {
+          src: 'https://images.unsplash.com/photo-1566492031773-4f4e44671857?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80',
+          alt: 'Foto de Michael Carter',
+        },
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    title="Creemos algo juntos"
+    subtitle="¿Listo para convertir tu visión en diseños irresistibles?"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Contrátame',
+        href: '/es/contact',
+      },
+    ]}
+  />
+
+  <!-- BlogLatestPost Widget **************** -->
+
+  <BlogLatestPosts
+    id="blog"
+    title="Explora mis artículos con ideas y aprendizajes de diseño"
+    information={`Sumérgete en un espacio de inspiración creativa con consejos prácticos e historias que enriquecerán tu proceso creativo.`}
+  >
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </BlogLatestPosts>
+</Layout>

--- a/src/pages/es/homes/saas.astro
+++ b/src/pages/es/homes/saas.astro
@@ -1,0 +1,305 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+
+import Header from '~/components/widgets/Header.astro';
+import Hero2 from '~/components/widgets/Hero2.astro';
+import Features from '~/components/widgets/Features.astro';
+import Steps2 from '~/components/widgets/Steps2.astro';
+import Content from '~/components/widgets/Content.astro';
+import Pricing from '~/components/widgets/Pricing.astro';
+
+import { headerData } from '~/navigation';
+import FAQs from '~/components/widgets/FAQs.astro';
+import BlogLatestPosts from '~/components/widgets/BlogLatestPosts.astro';
+
+const metadata = {
+  title: 'Página SaaS de demostración',
+};
+---
+
+<Layout metadata={metadata}>
+  <Fragment slot="header">
+    <Header
+      {...headerData(Astro.url)}
+      actions={[
+        {
+          variant: 'secondary',
+          text: 'Iniciar sesión',
+          href: '#',
+        },
+        {
+          variant: 'primary',
+          text: 'Crear cuenta',
+          href: '#',
+        },
+      ]}
+      isSticky
+    />
+  </Fragment>
+
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero2
+    tagline="Demo web SaaS"
+    actions={[
+      { variant: 'primary', target: '_blank', text: 'Comenzar', href: 'https://github.com/onwidget/astrowind' },
+      { text: 'Saber más', href: '#features' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1580481072645-022f9a6dbf27?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+      alt: 'Imagen de héroe de AstroWind',
+    }}
+  >
+    <Fragment slot="title">
+      Simplifica el diseño web con Astrowind: <br /> tu mejor aliado para <span class="text-accent dark:text-white highlight"
+        >SaaS</span
+      ><br />
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      <span class="hidden sm:inline">
+        Impulsa la creación de tu sitio con las soluciones <span class="font-semibold">AstroWind</span> para SaaS.</span
+      >
+      Combina sin esfuerzo el poder de Astro 5.0 y Tailwind CSS para crear sitios que conectan con tu marca y tu audiencia.
+    </Fragment>
+  </Hero2>
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    title="¿Por qué elegir AstroWind?"
+    subtitle="Cada una de estas características refuerza la propuesta de valor de AstroWind."
+    columns={2}
+    items={[
+      {
+        title: 'Integración de Astro 5.0 y Tailwind CSS',
+        description:
+          'Ofrece una combinación poderosa que mejora tanto el desarrollo como la experiencia de usuario. Permite crear sitios dinámicos y atractivos con un rendimiento optimizado.',
+        icon: 'tabler:layers-union',
+      },
+      {
+        title: 'Diseño versátil para startups, pymes y más',
+        description: `Adapta AstroWind con facilidad para que refleje la identidad única de tu proyecto. Su diseño flexible se ajusta a tus necesidades.`,
+        icon: 'tabler:artboard',
+      },
+      {
+        title: 'Personalización sencilla para portafolios y marketing',
+        description:
+          'Con una personalización intuitiva, muestra piezas de portafolio, casos de éxito y contenido clave. Ideal para profesionales creativos y empresas que desean destacar su experiencia.',
+        icon: 'tabler:writing',
+      },
+      {
+        title: 'Landing pages optimizadas y blogs atractivos',
+        description: `Las páginas de destino están diseñadas para cautivar visitantes y guiar acciones concretas. Además, el blog facilita compartir conocimientos y mantener a tu audiencia comprometida.`,
+        icon: 'tabler:podium',
+      },
+      {
+        title: 'Código listo para producción y tiempos de carga rápidos',
+        description: `Astro 5.0 garantiza cargas veloces y renderizado fluido. El código sigue buenas prácticas para mejorar la experiencia, el SEO y reducir rebotes.`,
+        icon: 'tabler:rocket',
+      },
+      {
+        title: 'Estructura SEO optimizada para mayor visibilidad',
+        description: `Cumple con las mejores prácticas de SEO mediante código limpio, HTML semántico y tiempos de carga excelentes. Así, AstroWind asegura que potenciales clientes encuentren tu oferta.`,
+        icon: 'tabler:eyeglass',
+      },
+    ]}
+  />
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    title="Casos de uso"
+    subtitle="Descubre cómo el diseño versátil de AstroWind ofrece soluciones a medida que impulsan el éxito."
+    isReversed
+    items={[
+      {
+        title: 'Descripción:',
+        description:
+          '¿Eres una startup con grandes metas? AstroWind potencia tu presencia. El template crea una experiencia online impecable, atrayendo inversionistas y clientes desde el día uno. Astro 5.0 y Tailwind CSS garantizan sitios impactantes y responsivos que dejan huella.',
+      },
+      {
+        title: 'Beneficios:',
+        description: `Permite construir sitios profesionales sin dedicar grandes recursos. <br /> Causa una primera impresión memorable con un diseño atractivo que refuerza tu propuesta de valor. <br /> Asegura que tu web luzca impecable y funcione en cualquier dispositivo. <br /> Conecta con inversionistas y clientes mediante contenido claro y navegación intuitiva.`,
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1620558138198-cfb9b4f3c294?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1671&q=80',
+      alt: 'Imagen de startup',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">
+        Historias de startups: <br /><span class="text-2xl">Lanzamientos con AstroWind</span>
+      </h3>
+    </Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Content Widget **************** -->
+
+  <Content
+    isAfterContent={true}
+    items={[
+      {
+        title: 'Descripción:',
+        description: `En negocios SaaS la experiencia de uso lo es todo. AstroWind facilita presentar tus soluciones de forma intuitiva. La integración con Astro 5.0 y Tailwind CSS asegura un sitio tan eficiente como tu software. Personaliza las páginas para comunicar el valor y resolver los retos de tus clientes.`,
+      },
+      {
+        title: 'Beneficios:',
+        description: `Garantiza un diseño coherente y centrado en el usuario. <br /> Comunica funcionalidades complejas con recursos visuales, animaciones y elementos interactivos. <br /> Prioriza necesidades y puntos de dolor con estructuras claras y navegación ordenada. <br /> Motiva a tus visitantes con CTAs estratégicos. <br /> Asegura una experiencia impecable en cualquier dispositivo.`,
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1531973486364-5fa64260d75b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1658&q=80',
+      alt: 'Imagen de negocio SaaS',
+    }}
+  >
+    <Fragment slot="content">
+      <div class="flex flex-col gap-6">
+        <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">
+          Experiencias SaaS memorables
+        </h3>
+        <p class="text-lg text-muted-foreground">
+          Convierte las demos y el onboarding en recorridos claros, con métricas y testimonios que refuerzan la decisión de compra.
+        </p>
+      </div>
+    </Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Steps2 Widget ****************** -->
+
+  <Steps2
+    title="Crea tu sitio SaaS en 5 pasos"
+    subtitle="Desde la planificación hasta el lanzamiento, AstroWind acompaña cada etapa."
+    items={[
+      {
+        title: '1. Define el posicionamiento',
+        description: 'Resume la propuesta de valor y la audiencia. Esto guiará la estructura del sitio y los mensajes clave.',
+      },
+      {
+        title: '2. Personaliza el héroe',
+        description: 'Adapta el titular, subtítulo y CTA para reflejar tu solución y resaltar un beneficio tangible.',
+      },
+      {
+        title: '3. Diseña la demo del producto',
+        description: 'Usa capturas y gráficos interactivos para mostrar cómo tu software resuelve tareas críticas.',
+      },
+      {
+        title: '4. Refuerza con prueba social',
+        description: 'Añade testimonios, logotipos de clientes y métricas reales que respalden la promesa.',
+      },
+      {
+        title: '5. Lanza y optimiza',
+        description: 'Publica, mide la conversión y ajusta textos y secciones con base en datos.',
+      },
+    ]}
+  />
+
+  <!-- Pricing Widget ***************** -->
+
+  <Pricing
+    title="Planes flexibles"
+    subtitle="Estructura planes claros para usuarios, equipos y clientes empresariales."
+    prices={[
+      {
+        title: 'Inicial',
+        price: 19,
+        period: 'al mes',
+        description: 'Ideal para productos en fase beta o MVPs centrados en validación temprana.',
+        items: [
+          { title: 'Hasta 1 000 usuarios activos mensuales' },
+          { title: 'Panel de administración básico' },
+          { title: 'Integración con herramientas de soporte' },
+        ],
+        callToAction: {
+          variant: 'primary',
+          text: 'Probar gratis',
+          href: '#',
+        },
+      },
+      {
+        title: 'Crecimiento',
+        hasRibbon: true,
+        ribbonTitle: 'Más popular',
+        price: 59,
+        period: 'al mes',
+        description: 'Perfecto para equipos que requieren automatización y analítica avanzada.',
+        items: [
+          { title: 'Usuarios ilimitados' },
+          { title: 'Paneles y reportes personalizados' },
+          { title: 'Automatizaciones preconfiguradas' },
+        ],
+        callToAction: {
+          variant: 'primary',
+          text: 'Solicitar demo',
+          href: '#',
+        },
+      },
+      {
+        title: 'Empresarial',
+        price: 'Habla con nosotros',
+        description: 'Para organizaciones que necesitan seguridad avanzada y soporte dedicado.',
+        items: [
+          { title: 'SLA a medida' },
+          { title: 'Integraciones personalizadas' },
+          { title: 'Gestión de cuentas clave' },
+        ],
+        callToAction: {
+          variant: 'secondary',
+          text: 'Contactar ventas',
+          href: '#',
+        },
+      },
+    ]}
+  />
+
+  <!-- FAQs Widget ******************** -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Resuelve las dudas más comunes de tus usuarios antes de que contacten al equipo."
+    items={[
+      {
+        title: '¿Qué necesito para lanzar el sitio?',
+        description:
+          'Solo tu branding y la información de tu producto. AstroWind incluye componentes listos para desplegar en plataformas estáticas o en tu infraestructura preferida.',
+      },
+      {
+        title: '¿Puedo conectar mi CRM o herramienta de soporte?',
+        description:
+          'Sí. Integra formularios con HubSpot, Pipedrive o Zendesk usando endpoints personalizados o servicios de automatización.',
+      },
+      {
+        title: '¿Cómo gestiono varios idiomas?',
+        description:
+          'AstroWind incluye utilidades de internacionalización. Duplica el contenido y controla rutas personalizadas para cada idioma.',
+      },
+      {
+        title: '¿Es compatible con estrategias SEO?',
+        description:
+          'Totalmente. Define metadatos, estructura semántica y blog optimizado para mejorar tu posicionamiento orgánico.',
+      },
+    ]}
+  />
+
+  <!-- BlogLatestPosts Widget ********* -->
+
+  <BlogLatestPosts
+    id="blog"
+    title="Mantente al día con el blog de AstroWind"
+    information={`Explora nuestra colección de artículos, guías y tutoriales sobre desarrollo web, tendencias de diseño y buenas prácticas para impulsar tu SaaS con AstroWind.`}
+  >
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </BlogLatestPosts>
+</Layout>

--- a/src/pages/es/homes/startup.astro
+++ b/src/pages/es/homes/startup.astro
@@ -1,0 +1,269 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+
+import Hero from '~/components/widgets/Hero.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+import Features2 from '~/components/widgets/Features2.astro';
+import Features from '~/components/widgets/Features.astro';
+import Stats from '~/components/widgets/Stats.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import Brands from '~/components/widgets/Brands.astro';
+
+import { YouTube } from 'astro-embed';
+
+const metadata = {
+  title: 'Landing page para startups',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero Widget ******************* -->
+
+  <Hero
+    tagline="Demo web para startups"
+    actions={[
+      {
+        variant: 'primary',
+        target: '_blank',
+        text: 'Obtener plantillas',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+      { text: 'Saber más', href: '#features' },
+    ]}
+  >
+    <Fragment slot="title">
+      Potencia la presencia digital de tu <span class="hidden sm:inline">startup</span> con las plantillas
+      <span class="text-accent dark:text-white highlight">AstroWind</span>
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      Da el salto al escaparate digital con las plantillas de <span class="font-semibold">AstroWind</span>. Fortalecen la
+      credibilidad de tu startup y amplían el alcance con mensajes claros y diseño profesional.
+    </Fragment>
+
+    <Fragment slot="image">
+      <YouTube id="gxBkghlglTg" title="Astro just Launched.... Could it be the ultimate web framework?" />
+      <style is:inline>
+        lite-youtube {
+          margin: 0 auto;
+          max-width: 100%;
+        }
+      </style>
+    </Fragment>
+  </Hero>
+
+  <!-- Features2 Widget ************** -->
+
+  <Features2
+    title="Quiénes somos"
+    subtitle="Creemos en convertir grandes ideas en experiencias web memorables. Somos desarrolladores apasionados que
+    simplificamos la creación de sitios uniendo la innovación de Astro 5.0 con la flexibilidad de Tailwind CSS. Así tu marca
+    se expresa con identidad propia."
+  >
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Features2>
+
+  <!-- Stats Widget ****************** -->
+
+  <Stats
+    title="El impacto de AstroWind"
+    subtitle="Las cifras reflejan la confianza de nuestra comunidad y los resultados que ayudamos a conseguir."
+    stats={[
+      { title: 'Descargas', amount: '182K' },
+      { title: 'Sitios lanzados', amount: '87' },
+      { title: 'Valoración de usuarios', amount: '4.8' },
+      { title: 'Clientes satisfechos', amount: '116K' },
+    ]}
+  />
+
+  <!-- Brands Widget ****************** -->
+
+  <Brands
+    title="Alianzas y colaboraciones"
+    subtitle="La co-creación impulsa la innovación. Estas marcas confían en nuestros componentes y procesos."
+    icons={[]}
+    images={[
+      {
+        src: 'https://cdn.pixabay.com/photo/2015/05/26/09/37/paypal-784404_1280.png',
+        alt: 'Paypal',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2021/12/06/13/48/visa-6850402_1280.png',
+        alt: 'Visa',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2013/10/01/10/29/ebay-189064_1280.png',
+        alt: 'Ebay',
+      },
+
+      {
+        src: 'https://cdn.pixabay.com/photo/2015/04/13/17/45/icon-720944_1280.png',
+        alt: 'Youtube',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2013/02/12/09/07/microsoft-80658_1280.png',
+        alt: 'Microsoft',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2015/04/23/17/41/node-js-736399_1280.png',
+        alt: 'Node JS',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2015/10/31/12/54/google-1015751_1280.png',
+        alt: 'Google',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2021/12/06/13/45/meta-6850393_1280.png',
+        alt: 'Meta',
+      },
+      {
+        src: 'https://cdn.pixabay.com/photo/2013/01/29/22/53/yahoo-76684_1280.png',
+        alt: 'Yahoo',
+      },
+    ]}
+  />
+
+  <!-- Features2 Widget ************** -->
+
+  <Features2
+    title="¿Qué ofrecemos?"
+    subtitle="Un catálogo de plantillas para negocios, portafolios, e-commerce, blogs y mucho más, listas para lanzar con
+    tu stack preferido."
+    items={[
+      {
+        title: 'Guías de instalación',
+        description:
+          'Incluimos instrucciones claras para descargar las plantillas y desplegarlas en los principales CMS o plataformas estáticas.',
+        icon: 'flat-color-icons:document',
+      },
+      {
+        title: 'Demos y vistas previas',
+        description:
+          'Explora demos interactivas para visualizar cómo se comporta la plantilla antes de invertir tiempo o presupuesto.',
+        icon: 'flat-color-icons:template',
+      },
+      {
+        title: 'Soporte técnico',
+        description:
+          'Nuestro equipo responde dudas de implementación y te guía para personalizar el resultado final.',
+        icon: 'flat-color-icons:voice-presentation',
+      },
+    ]}
+  >
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Features2>
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    title="Cómo impulsamos a las startups"
+    subtitle="Componentes listos para inspirar confianza en clientes e inversionistas."
+    columns={2}
+    items={[
+      {
+        title: 'Historias de clientes',
+        description:
+          'Comparte casos de éxito y validación en medios para reforzar la tracción temprana de tu startup.',
+        icon: 'tabler:message-chatbot',
+      },
+      {
+        title: 'Integraciones simples',
+        description:
+          'Conecta formularios y automatizaciones con Zapier, Make o APIs personalizadas sin reescribir todo el sitio.',
+        icon: 'tabler:plug-connected',
+      },
+      {
+        title: 'Secciones de producto limpias',
+        description:
+          'Describe funcionalidades, screenshots y recorridos de onboarding con bloques modulares que se adaptan a tu narrativa.',
+        icon: 'tabler:layout-2',
+      },
+      {
+        title: 'Llamados a la acción efectivos',
+        description:
+          'Componentes listos para captar registros beta, solicitudes de demo o acceso anticipado.',
+        icon: 'tabler:cursor-text',
+      },
+    ]}
+  />
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    title="Motor creativo"
+    subtitle="Desde la idea inicial hasta el pitch final, te acompañamos con recursos visuales y contenido adaptable."
+    items={[
+      {
+        title: 'Narrativa consistente',
+        description:
+          'Mantén una voz coherente entre la landing, el pitch deck y la comunicación con inversionistas.',
+        icon: 'tabler:book',
+      },
+      {
+        title: 'Experiencias inmersivas',
+        description:
+          'Añade video, animaciones o demos incrustadas para mostrar el producto en acción sin sacrificar rendimiento.',
+        icon: 'tabler:photo-video',
+      },
+      {
+        title: 'Personalización a tu ritmo',
+        description:
+          'Cambia colores, tipografías y layouts con utilidades Tailwind para experimentar rápido y validar diseños.',
+        icon: 'tabler:color-swatch',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget ************ -->
+
+  <CallToAction
+    title="Listo para lanzar"
+    subtitle="Escala tu presencia digital con plantillas optimizadas para conversiones y crecimiento."
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar ahora',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+      { variant: 'secondary', text: 'Solicitar asesoría', href: '#contacto' },
+    ]}
+  />
+
+  <!-- FAQs Widget ******************** -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Respuestas rápidas para los equipos que preparan su próximo lanzamiento."
+    items={[
+      {
+        title: '¿Qué incluye la descarga?',
+        description:
+          'Acceso a componentes Astro y Tailwind, archivos de contenido de ejemplo y documentación paso a paso para personalizar.',
+      },
+      {
+        title: '¿Cómo adapto la plantilla a mi branding?',
+        description:
+          'Modifica variables de Tailwind, tipografías y assets en minutos. Puedes crear temas claros u oscuros sin romper el diseño.',
+      },
+      {
+        title: '¿Aceptan contribuciones?',
+        description:
+          'Sí. Abrimos issues en GitHub para mejoras, traducciones adicionales y nuevos componentes.',
+      },
+      {
+        title: '¿Puedo combinarla con un CMS?',
+        description:
+          'AstroWind se integra con CMS headless como Contentful, Sanity o Strapi mediante APIs y colecciones personalizadas.',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -13,113 +13,368 @@ import CallToAction from '~/components/widgets/CallToAction.astro';
 import Testimonials from '~/components/widgets/Testimonials.astro';
 
 const metadata = {
-  title: 'Eduardo Vieira — Automatización Industrial & Ingeniero IIoT',
+  title: 'Eduardo Vieira — Ingeniero de Automatización Industrial e IIoT',
   ignoreTitleTemplate: true,
 };
 ---
 
 <Layout metadata={metadata}>
+  <!-- Hero Widget ******************* -->
+
   <Hero
     tagline="Automatización Industrial | IIoT | SCADA | Integración en la Nube"
     actions={[
       { variant: 'primary', text: 'Contáctame', href: '/es/contact', icon: 'tabler:mail' },
-      { text: 'Explorar Servicios', href: '/es/services', icon: 'tabler:device-desktop-code' }
+      { text: 'Explorar Servicios', href: '/es/services', icon: 'tabler:device-desktop-code' },
     ]}
     image={{ src: '~/assets/images/panel.png', alt: 'Tablero de control de automatización industrial' }}
   >
     <Fragment slot="title">
-      De <span class="text-accent dark:text-white highlight">lógica PLC</span> a información en la nube
+      De la <span class="text-accent dark:text-white highlight">lógica PLC</span> a la inteligencia en la nube
     </Fragment>
+
     <Fragment slot="subtitle">
       <span class="hidden sm:inline">
-        <span class="font-semibold">Soy Eduardo Vieira,</span> ingeniero de Automatización Industrial e IIoT. Conecto el piso de planta con la nube, transformando señales de máquina en inteligencia accionable.
+        <span class="font-semibold">Soy Eduardo Vieira,</span> Ingeniero de Automatización Industrial e IIoT. Conecto el piso
+        de planta con la nube, transformando señales crudas en información confiable para la toma de decisiones.
       </span>
       <span class="block mb-1 sm:hidden font-bold text-blue-600">Ingeniero de Automatización Industrial e IIoT</span>
-      Con más de 7 años diseñando sistemas de automatización de extremo a extremo, entrego lógica PLC confiable, interfaces SCADA intuitivas y tuberías de datos seguras.
+      Con más de siete años diseñando sistemas de automatización de punta a punta, entrego lógica PLC confiable, interfaces
+      SCADA intuitivas y flujos de datos seguros que permiten manufactura inteligente.
     </Fragment>
   </Hero>
 
+  <!-- Note Widget ******************* -->
+
   <Note>
     <Fragment slot="content">
-      <span class="font-bold">100% Job Success</span> en Upwork con alianzas en Norte y Latinoamérica
+      <span class="font-bold">100% Job Success</span> en Upwork con alianzas en Norteamérica y Latinoamérica
     </Fragment>
   </Note>
+
+  <!-- Features Widget *************** -->
 
   <Features
     id="skills"
     tagline="Competencias Clave"
-    title="Experiencia en Automatización Industrial e IIoT"
-    subtitle="Entrego la pila completa—desde dispositivos de campo hasta analítica empresarial—con foco en confiabilidad y ROI."
+    title="Experiencia integral en Automatización Industrial e IIoT"
+    subtitle="Entrego la pila completa—desde dispositivos de campo hasta analítica empresarial—con foco en confiabilidad, mantenibilidad y ROI medible."
     items={[
-      { title: 'Entrega de Proyectos de Punta a Punta', description: 'Descubrimiento, diseño, programación, puesta en marcha y optimización.', icon: 'tabler:route' },
-      { title: 'Arquitectura IIoT', description: 'Pipelines resilientes con MQTT y Sparkplug B.', icon: 'tabler:cloud-computing' },
-      { title: 'Experto Multi-PLC', description: 'Siemens, Allen-Bradley, Mitsubishi, CODESYS, ABB.', icon: 'tabler:device-analytics' },
-      { title: 'SCADA & Visualización', description: 'Ignition, ThingsBoard, FUXA y dashboards claros.', icon: 'tabler:device-desktop-analytics' },
-      { title: 'Integración Nube & Borde', description: 'Gateways, PCs industriales y nubes (AWS, Azure, GCP).', icon: 'tabler:topology-star-3' },
-      { title: 'Colaboración Bilingüe', description: 'Español nativo y fluido en inglés.', icon: 'tabler:world' },
+      {
+        title: 'Entrega de proyectos de punta a punta',
+        description:
+          'Descubrimiento de requerimientos, diseño del sistema, programación, puesta en marcha y optimización continua para iniciativas llave en mano.',
+        icon: 'tabler:route',
+      },
+      {
+        title: 'Arquitectura IIoT resiliente',
+        description:
+          'Diseño pipelines que capturan, contextualizan y publican datos OT mediante MQTT, Sparkplug B y marcos IIoT modernos.',
+        icon: 'tabler:cloud-computing',
+      },
+      {
+        title: 'Experticia multi-PLC',
+        description:
+          'Programación de controladores Siemens, Allen-Bradley, Mitsubishi, CODESYS y ABB con lógica estructurada y documentada para activos nuevos y legados.',
+        icon: 'tabler:device-analytics',
+      },
+      {
+        title: 'SCADA y visualización',
+        description:
+          'Desarrollo de interfaces Ignition, ThingsBoard, FUXA y dashboards Node-RED que convierten datos complejos en vistas intuitivas.',
+        icon: 'tabler:device-desktop-analytics',
+      },
+      {
+        title: 'Integración edge y cloud',
+        description:
+          'Despliegue de gateways industriales, PCs edge y servicios en AWS, Azure o GCP para monitoreo remoto, alertas y analítica en tiempo real.',
+        icon: 'tabler:topology-star-3',
+      },
+      {
+        title: 'Colaboración bilingüe',
+        description:
+          'Hablo español nativo e inglés fluido, facilitando proyectos con equipos en Norteamérica y Latinoamérica.',
+        icon: 'tabler:world',
+      },
+      {
+        title: 'Socio freelance comprobado',
+        description:
+          'Clientes internacionales confían en mí para proyectos críticos, respaldado por un 100% de Job Success y contratos recurrentes.',
+        icon: 'tabler:thumb-up',
+      },
     ]}
   />
+
+  <!-- Content Widget **************** -->
 
   <Content
     isReversed
     tagline="Acerca de"
     title="Tu puente entre sistemas mecánicos e inteligencia digital"
     items={[
-      { title: 'Ingeniero Mecánico de base', description: 'Diseño y programación de maquinaria a medida.' },
-      { title: 'Ingeniero de Automatización por pasión', description: 'PLC, SCADA y edge computing con foco en valor.' },
-      { title: 'Socio Confiable', description: 'Experiencia remota con clientes de América.' },
+      {
+        title: 'Ingeniero Mecánico de base',
+        description:
+          'Inicié diseñando y programando maquinaria a medida, lo que me dio fundamentos en procesos físicos, seguridad y operación.',
+      },
+      {
+        title: 'Ingeniero de Automatización por pasión',
+        description:
+          'Especialista en lógica PLC, desarrollo SCADA y edge computing para conectar activos de planta con la toma de decisiones.',
+      },
+      {
+        title: 'Socio global confiable',
+        description:
+          '100% de satisfacción en Upwork con experiencia remota junto a fabricantes de América del Norte y del Sur.',
+      },
     ]}
-    image={{ src: 'https://images.unsplash.com/photo-1581092918056-0c4c3acd3789?auto=format&fit=crop&w=2070&q=80', alt: 'Ingeniero industrial' }}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581092918056-0c4c3acd3789?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Ingeniero industrial revisando planos de automatización',
+    }}
   >
     <Fragment slot="content">
       <p>
-        Construyo la pila IIoT completa: controladores, edge, MQTT y nube para visibilidad en tiempo real y decisiones informadas.
+        Mi carrera comenzó en el piso de planta diseñando sistemas mecánicos y escribiendo lógica PLC para equipos a medida. Ese
+        trabajo me enseñó cómo operan los equipos de producción, dónde se origina el tiempo muerto y la importancia de entregar
+        soluciones de control confiables.
+      </p>
+      <br />
+      <p>
+        Con la aceleración de la Industria 4.0 me enfoqué en el Internet Industrial de las Cosas. Hoy construyo pipelines
+        completos—controladores, edge, MQTT y nube—para que las organizaciones monitoreen operaciones en tiempo real, reduzcan
+        paradas y obtengan información accionable.
+      </p>
+      <br />
+      <p>
+        Disfruto trabajar en entornos complejos y multi-plataforma. Sea Siemens, Allen-Bradley, Mitsubishi, ABB o CODESYS,
+        selecciono la tecnología adecuada, documento cada paso y entrego sistemas que tu equipo puede mantener con confianza.
       </p>
     </Fragment>
   </Content>
 
+  <!-- Content Widget **************** -->
+
+  <Content
+    isAfterContent
+    tagline="Por qué me eligen"
+    title="Soluciones de automatización diseñadas para la realidad industrial"
+    items={[
+      {
+        title: 'Propiedad unificada',
+        description:
+          'Un solo socio para lógica PLC, dashboards SCADA e integraciones cloud reduce brechas y acelera la puesta en marcha.',
+      },
+      {
+        title: 'Arquitecturas escalables',
+        description:
+          'Cada solución se diseña para crecer; agrega líneas, plantas o analítica sin rehacer toda la arquitectura.',
+      },
+      {
+        title: 'Documentación y habilitación',
+        description:
+          'Incluyo documentación clara, capacitación y soporte para que tu equipo pueda operar el sistema con seguridad.',
+      },
+      {
+        title: 'Confiabilidad a largo plazo',
+        description:
+          'Implemento manejo de fallas, ciberseguridad OT y estrategias de mantenimiento preventivo para mantener la operación resiliente.',
+      },
+    ]}
+    image={{
+      src: '~/assets/images/plc.jpg',
+      alt: 'Entorno de programación PLC',
+    }}
+  >
+    <Fragment slot="content">Confiado por líderes de manufactura que necesitan un socio OT-IT de confianza</Fragment>
+
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
+  </Content>
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Mi enfoque para proyectos de manufactura inteligente"
+    items={[
+      {
+        title: 'Paso 1: <span class="font-medium">Descubrimiento y auditoría de datos</span>',
+        description:
+          'Mapeamos procesos, equipos críticos e infraestructura existente para comprender objetivos, restricciones y estado de los datos.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Paso 2: <span class="font-medium">Arquitectura y diseño</span>',
+        description:
+          'Diseño lógica de control, redes, modelos de datos y capas de seguridad que entregan información contextualizada.',
+        icon: 'tabler:layout-board',
+      },
+      {
+        title: 'Paso 3: <span class="font-medium">Implementación y puesta en marcha</span>',
+        description:
+          'Desarrollo código PLC, dashboards SCADA y gateways edge, probándolos junto a tu equipo de operaciones.',
+        icon: 'tabler:bolt',
+      },
+      {
+        title: 'Paso 4: <span class="font-medium">Habilitación y soporte</span>',
+        description:
+          'Capacito a tu personal, entrego documentación y brindo soporte continuo para garantizar valor desde el día uno y más allá.',
+        icon: 'tabler:headset',
+      },
+    ]}
+    image={{
+      src: '~/assets/images/automation.jpg',
+      alt: 'Resumen del proceso de automatización industrial',
+    }}
+  />
+
+  <!-- Features2 Widget ************** -->
+
   <Features2
     title="El viaje de datos OT a IT"
-    subtitle="Un plano probado que captura, contextualiza y entrega datos industriales."
+    subtitle="Cada proyecto sigue un plano probado que captura, contextualiza y entrega datos industriales donde más importan."
     tagline="Metodología"
     items={[
-      { title: 'Adquisición de señales', description: 'PLC, sensores y controladores legados.', icon: 'tabler:schema' },
-      { title: 'Normalización en el borde', description: 'Limpiar y estandarizar datos.', icon: 'tabler:cpu' },
-      { title: 'Mensajería segura', description: 'MQTT y Sparkplug B con seguridad.', icon: 'tabler:lock' },
-      { title: 'Integración en la nube', description: 'AWS, Azure o GCP.', icon: 'tabler:cloud-up' },
-      { title: 'Visualización & Alertas', description: 'KPIs y alarmas accionables.', icon: 'tabler:device-analytics' },
-      { title: 'Soporte continuo', description: 'Documentar, entrenar y optimizar.', icon: 'tabler:arrows-exchange' },
+      {
+        title: 'Captura de señales',
+        description: 'Adquisición de PLCs, sensores y controladores legados sin interrumpir la producción.',
+        icon: 'tabler:schema',
+      },
+      {
+        title: 'Normalización en el borde',
+        description: 'Limpieza, agregación y estandarización de datos usando dispositivos edge e IPCs.',
+        icon: 'tabler:cpu',
+      },
+      {
+        title: 'Mensajería segura',
+        description: 'Publicación vía MQTT y Sparkplug B con autenticación robusta y cifrado.',
+        icon: 'tabler:lock',
+      },
+      {
+        title: 'Integración cloud',
+        description: 'Conexión con AWS IoT, Azure IoT o GCP para almacenamiento, analítica y aplicaciones empresariales.',
+        icon: 'tabler:cloud-up',
+      },
+      {
+        title: 'Visualización y alertas',
+        description: 'HMIs operativas y dashboards ejecutivos con KPIs accionables y alarmas configurables.',
+        icon: 'tabler:device-analytics',
+      },
+      {
+        title: 'Soporte de ciclo de vida',
+        description: 'Documentación, entrenamiento y optimización continua para que la solución evolucione con tu negocio.',
+        icon: 'tabler:arrows-exchange',
+      },
     ]}
   >
-    <Fragment slot="bg"><div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div></Fragment>
+    <Fragment slot="bg">
+      <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
+    </Fragment>
   </Features2>
 
-  <BlogLatestPosts title="Últimas ideas desde la planta" information={`Buenas prácticas de PLC, arquitecturas IIoT y casos prácticos.`} />
+  <!-- BlogLatestPosts Widget ******* -->
+
+  <BlogLatestPosts
+    title="Últimas ideas desde la planta"
+    information={`Mantente al frente de la Industria 4.0. Comparto guías prácticas sobre PLC, arquitecturas IIoT, despliegues MQTT y casos reales de manufactura inteligente.`}
+  />
+
+  <!-- FAQs Widget ******************* -->
 
   <FAQs
     title="Preguntas frecuentes"
-    subtitle="Respuestas a lo más consultado sobre mis servicios."
+    subtitle="Respuestas a las dudas más comunes al trabajar conmigo en automatización e IIoT."
     tagline="FAQs"
     classes={{ container: 'max-w-6xl' }}
     items={[
-      { title: '¿Qué PLCs soportas?', description: 'Siemens, Allen-Bradley, Mitsubishi, ABB, CODESYS.' },
-      { title: '¿Qué incluye una integración IIoT?', description: 'Gateway, MQTT/Sparkplug, segmentación OT, modelos de datos y dashboards.' },
-      { title: '¿Incluyes documentación y capacitación?', description: 'Siempre. Entregables y entrenamiento para tu equipo.' },
+      {
+        title: '¿Qué plataformas PLC manejas?',
+        description:
+          'Trabajo con Siemens (TIA Portal), Allen-Bradley (Studio 5000), Mitsubishi (GX Works), ABB y ecosistemas CODESYS. Adapto librerías y documentación a tus estándares.',
+      },
+      {
+        title: '¿Qué incluye un proyecto IIoT?',
+        description:
+          'Configuración de gateways edge, MQTT/Sparkplug B, segmentación OT, modelado de datos, ingesta en la nube, dashboards y capacitación de tu equipo.',
+      },
+      {
+        title: '¿Entregas documentación y entrenamiento?',
+        description:
+          'Siempre. Cada proyecto concluye con documentación estructurada, código versionado y sesiones remotas o presenciales para tu personal.',
+      },
+      {
+        title: '¿Cómo aseguras ciberseguridad y confiabilidad?',
+        description:
+          'Aplico defensa en profundidad: credenciales seguras, mensajería cifrada, segmentación de red y monitoreo continuo, junto con lógica tolerante a fallas y redundancia de datos.',
+      },
+      {
+        title: '¿Dónde estás ubicado y cómo colaboras?',
+        description:
+          'Resido en Argentina y colaboro de forma remota con clientes de toda América. Me adapto a tus herramientas, idioma y zona horaria para mantener al equipo alineado.',
+      },
+      {
+        title: '¿Ofreces soporte post implementación?',
+        description:
+          'Claro. Puedo acompañar con monitoreo remoto, mejoras, nuevas funciones y asesoramiento estratégico para tu hoja de ruta Industria 4.0.',
+      },
     ]}
   />
 
-  <Stats stats={[{ title: 'Años integrando OT & IT', amount: '7+' }, { title: 'Proyectos', amount: '50+' }, { title: 'Upwork JSS', amount: '100%' }]} />
+  <!-- Testimonials Widget *********** -->
+
+  <Testimonials
+    title="Testimonios de clientes"
+    subtitle="Opiniones reales de equipos que confiaron en mí para modernizar su automatización e IIoT."
+    testimonials={[
+      {
+        testimonial:
+          'Excelente trabajo de Eduardo. Su dominio de MQTT, protocolos industriales y edge computing se notó desde el primer día. Hoy vemos nuestro proceso crítico en tiempo real.',
+        name: 'Cliente de Control de Procesos',
+        job: 'Proyecto Gateway PLC a la nube',
+      },
+      {
+        testimonial:
+          'Eduardo conectó nuestra línea Siemens a Azure sin detener la producción. La documentación y capacitación facilitaron que nuestros técnicos se apropien del sistema.',
+        name: 'Líder de Ingeniería de Manufactura',
+        job: 'Programa de modernización IIoT',
+      },
+      {
+        testimonial:
+          'Trabajando en inglés y español mantuvo a todos alineados y entregó una actualización SCADA impecable. Los nuevos dashboards nos dan la visibilidad que necesitábamos.',
+        name: 'Director de Operaciones',
+        job: 'Modernización HMI & SCADA',
+      },
+    ]}
+    callToAction={{
+      target: '_blank',
+      text: 'Ver mi perfil en Upwork',
+      href: 'https://www.upwork.com/freelancers/~01f21c52fa13e6a195',
+      icon: 'tabler:external-link',
+    }}
+  />
+
+  <!-- Stats Widget ****************** -->
+
+  <Stats
+    stats={[
+      { title: 'Años integrando OT & IT', amount: '7+' },
+      { title: 'Proyectos de Automatización e IIoT entregados', amount: '50+' },
+      { title: 'Job Success en Upwork', amount: '100%' },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
 
   <CallToAction
     actions={[
       { variant: 'primary', text: 'Contáctame', href: '/es/contact', icon: 'tabler:mail' },
-      { text: 'Ver Portafolio', href: '/es/portfolio' },
+      { text: 'Ver portafolio', href: '/es/portfolio' },
     ]}
   >
     <Fragment slot="title">Construyamos el futuro de tu fábrica</Fragment>
-    <Fragment slot="subtitle">De un solo PLC a toda la planta conectada, puedo ayudar.</Fragment>
+    <Fragment slot="subtitle">
+      Ya sea programar un PLC, modernizar tu SCADA o conectar toda la planta a la nube, estoy listo para ayudarte a habilitar manufactura inteligente.
+    </Fragment>
   </CallToAction>
 </Layout>
-
-
-

--- a/src/pages/es/landing/click-through.astro
+++ b/src/pages/es/landing/click-through.astro
@@ -1,0 +1,41 @@
+---
+import Layout from '~/layouts/LandingLayout.astro';
+
+import Hero2 from '~/components/widgets/Hero2.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Demo de landing click-through',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero2
+    tagline="Demo click-through"
+    title="Landing click-through: el puente perfecto hacia la conversión"
+    subtitle="Aprende a diseñar una landing click-through que guíe al visitante sin fricciones hasta tu oferta principal."
+    actions={[
+      { variant: 'primary', text: 'Llamada a la acción', href: '#', icon: 'tabler:square-rounded-arrow-right' },
+      { text: 'Saber más', href: '#' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1516321497487-e288fb19713f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+      alt: 'Imagen hero para landing click-through',
+    }}
+  />
+
+  <CallToAction
+    title="Muy pronto"
+    subtitle="Estamos preparando el contenido completo de estas páginas demo. ¡Mantente atento!"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar plantilla',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/landing/lead-generation.astro
+++ b/src/pages/es/landing/lead-generation.astro
@@ -1,0 +1,41 @@
+---
+import Layout from '~/layouts/LandingLayout.astro';
+
+import Hero from '~/components/widgets/Hero.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Demo de landing para generación de leads',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero
+    tagline="Demo de landing de generación de leads"
+    title="Landing efectiva para captar leads: domina los fundamentos"
+    subtitle="Descubre cómo crear una landing que convierta curiosos en prospectos entusiasmados. Abre con un titular contundente que hable directamente a tu audiencia objetivo."
+    actions={[
+      { variant: 'primary', text: 'Llamada a la acción', href: '#', icon: 'tabler:square-rounded-arrow-right' },
+      { text: 'Saber más', href: '#' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1597423498219-04418210827d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1674&q=80',
+      alt: 'Imán atrayendo tornillos. Demo de landing para generación de leads',
+    }}
+  />
+
+  <CallToAction
+    title="Muy pronto"
+    subtitle="Estamos ultimando el contenido de estas páginas demo. ¡Muy pronto estará disponible!"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar plantilla',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/landing/pre-launch.astro
+++ b/src/pages/es/landing/pre-launch.astro
@@ -1,0 +1,41 @@
+---
+import Layout from '~/layouts/LandingLayout.astro';
+
+import Hero2 from '~/components/widgets/Hero2.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Landing de pre-lanzamiento',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero2
+    tagline="Demo de pre-lanzamiento"
+    title="Landing de pre-lanzamiento: genera expectativa antes del gran anuncio"
+    subtitle="Diseña una página de Próximamente que deje a tu audiencia contando los días para el lanzamiento."
+    actions={[
+      { variant: 'primary', text: 'Llamada a la acción', href: '#', icon: 'tabler:square-rounded-arrow-right' },
+      { text: 'Saber más', href: '#' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1558803116-c1b4ac867b31?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80',
+      alt: 'Tienda con letrero de Próximamente. Landing de pre-lanzamiento',
+    }}
+  />
+
+  <CallToAction
+    title="Muy pronto"
+    subtitle="Estamos preparando el contenido final de estas páginas demo. ¡Pronto estarán disponibles!"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar plantilla',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/landing/product.astro
+++ b/src/pages/es/landing/product.astro
@@ -1,0 +1,41 @@
+---
+import Layout from '~/layouts/LandingLayout.astro';
+
+import Hero from '~/components/widgets/Hero.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Demo de landing de producto',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero
+    tagline="Demo de detalles de producto"
+    title="Landing de producto: destaca con precisión y emoción"
+    subtitle="Guía paso a paso para diseñar una landing que muestre cada aspecto de tu producto o servicio."
+    actions={[
+      { variant: 'primary', text: 'Llamada a la acción', href: '#', icon: 'tabler:square-rounded-arrow-right' },
+      { text: 'Saber más', href: '#' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1473188588951-666fce8e7c68?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2174&q=80',
+      alt: 'Destacando un producto. Demo de landing de detalles',
+    }}
+  />
+
+  <CallToAction
+    title="Muy pronto"
+    subtitle="Estamos trabajando en el contenido completo de estas páginas de demostración. ¡Lo verás muy pronto!"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar plantilla',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/landing/sales.astro
+++ b/src/pages/es/landing/sales.astro
@@ -1,0 +1,41 @@
+---
+import Layout from '~/layouts/LandingLayout.astro';
+
+import Hero2 from '~/components/widgets/Hero2.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Demo de landing de ventas',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero2
+    tagline="Demo de venta narrativa"
+    title="Ventas con historia: convence con una landing de formato largo"
+    subtitle="Explora cómo construir una landing que narra, persuade y convierte paso a paso."
+    actions={[
+      { variant: 'primary', text: 'Llamada a la acción', href: '#', icon: 'tabler:square-rounded-arrow-right' },
+      { text: 'Saber más', href: '#' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1621452773781-0f992fd1f5cb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1626&q=80',
+      alt: 'Niños contando una historia. Demo de landing de ventas en formato largo',
+    }}
+  />
+
+  <CallToAction
+    title="Muy pronto"
+    subtitle="Estamos completando el contenido de estas páginas demo. ¡Publicaremos las novedades en breve!"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar plantilla',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/landing/subscription.astro
+++ b/src/pages/es/landing/subscription.astro
@@ -1,0 +1,41 @@
+---
+import Layout from '~/layouts/LandingLayout.astro';
+
+import Hero2 from '~/components/widgets/Hero2.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Demo de landing de suscripción',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero2 Widget ******************* -->
+
+  <Hero2
+    tagline="Demo de landing de suscripción"
+    title="Landing de suscripción: convierte visitas casuales en miembros fieles"
+    subtitle="Descubre la fórmula para una landing de suscripción que haga que tu audiencia regrese por más."
+    actions={[
+      { variant: 'primary', text: 'Llamada a la acción', href: '#', icon: 'tabler:square-rounded-arrow-right' },
+      { text: 'Saber más', href: '#' },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1593510987046-1f8fcfc512a0?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
+      alt: 'Imagen irónica sobre cancelar una suscripción. Demo de landing de suscripción',
+    }}
+  />
+
+  <CallToAction
+    title="Muy pronto"
+    subtitle="Estamos afinando el contenido de estas páginas demo. ¡Comparte tus expectativas y vuelve pronto!"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Descargar plantilla',
+        href: 'https://github.com/onwidget/astrowind',
+        icon: 'tabler:download',
+      },
+    ]}
+  />
+</Layout>

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -4,24 +4,187 @@ import HeroText from '~/components/widgets/HeroText.astro';
 import Content from '~/components/widgets/Content.astro';
 import CallToAction from '~/components/widgets/CallToAction.astro';
 
-const metadata = { title: 'Portafolio | Eduardo Vieira' };
+const metadata = {
+  title: 'Portafolio | Eduardo Vieira - Ingeniero de Automatización Industrial e IIoT',
+};
 ---
 
 <Layout metadata={metadata}>
-  <HeroText title="Proyectos Destacados" subtitle="Muestras de automatización e IIoT que conectan PLC, visualización y nube." />
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    title="Proyectos destacados"
+    subtitle="Una muestra de implementaciones de automatización e IIoT que conectan lógica PLC, visualización y analítica en la nube."
+  />
+
+  <!-- Content Widget ******************* -->
 
   <Content
     isReversed
     tagline="Integración IIoT"
-    title="Gateway PLC a Nube para Control de Proceso"
-    items={[{ title: 'Problema', description: 'Visibilidad remota limitada.' }, { title: 'Solución', description: 'MQTT Sparkplug B a AWS.' }, { title: 'Resultado', description: 'Dashboards y alertas 24/7.' }]}
-    image={{ src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=2070&q=80', alt: 'PLC a nube' }}
+    title="Gateway MQTT de PLC a la nube para control de procesos"
+    items={[
+      {
+        title: 'Problema',
+        description:
+          'Un fabricante de procesos necesitaba visibilidad remota sobre una línea crítica controlada por un PLC Mitsubishi, pero el área de IT corporativa no tenía conectividad OT.',
+      },
+      {
+        title: 'Solución',
+        description:
+          'Diseñé e implementé un gateway edge que consultó el PLC vía Modbus, normalizó datos en Python y publicó cargas Sparkplug B estructuradas en AWS IoT mediante MQTT.',
+      },
+      {
+        title: 'Resultado',
+        description:
+          'Operaciones obtuvo dashboards 24/7 y alertas automáticas, reduciendo visitas presenciales y acelerando la respuesta ante desvíos.',
+      },
+      {
+        title: 'Tecnologías utilizadas',
+        description: 'PLC Mitsubishi, MQTT, Sparkplug B, Python, AWS IoT, gateway industrial Linux.',
+      },
+      {
+        title: 'Testimonio',
+        description:
+          '“Excelente trabajo de Eduardo. Su dominio de MQTT, protocolos industriales y edge computing se notó desde el primer día. ¡Altamente recomendado!”',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=2070&q=80',
+      alt: 'PLC conectado a infraestructura en la nube',
+    }}
   />
 
-  <CallToAction actions={[{ variant: 'primary', text: 'Hablar del proyecto', href: '/es/contact', icon: 'tabler:mail' }]}>
-    <Fragment slot="title">Llevemos tu idea a producción</Fragment>
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isAfterContent
+    tagline="Sistemas de seguridad"
+    title="Retrofit de PLC de seguridad Mitsubishi para línea de envasado"
+    items={[
+      {
+        title: 'Problema',
+        description:
+          'Un OEM de packaging debía actualizar la seguridad para cumplir nuevas normativas en múltiples zonas sin detener la producción por largos periodos.',
+      },
+      {
+        title: 'Solución',
+        description:
+          'Reingeniería de la arquitectura de seguridad con PLCs de seguridad Mitsubishi, rediseño de circuitos de paro de emergencia y mensajería diagnóstica hacia el controlador principal y la HMI.',
+      },
+      {
+        title: 'Resultado',
+        description:
+          'Se logró la conformidad normativa, se redujeron disparos innecesarios y mantenimiento puede aislar fallas rápidamente gracias a alarmas detalladas.',
+      },
+      {
+        title: 'Tecnologías utilizadas',
+        description: 'PLC de seguridad Mitsubishi, GX Works, relevadores de seguridad, rediseño de tableros, documentación estructurada.',
+      },
+      {
+        title: 'Testimonio',
+        description:
+          '“La atención al detalle y las pruebas rigurosas de Eduardo nos permitieron aprobar la auditoría de seguridad en el primer intento. La documentación fue impecable.”',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581091012184-7ac3a0cfe129?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Tablero de control con PLC de seguridad',
+    }}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isReversed
+    tagline="Modernización HMI & SCADA"
+    title="Upgrade con Ignition y ThingsBoard para planta multi-línea"
+    items={[
+      {
+        title: 'Problema',
+        description:
+          'Las HMIs legadas ofrecían visibilidad limitada, carecían de acceso remoto y demandaban mucho esfuerzo para actualizarse en tres líneas de producción.',
+      },
+      {
+        title: 'Solución',
+        description:
+          'Reconstruí el stack SCADA en Ignition y ThingsBoard con plantillas reutilizables, soporte multilingüe y dashboards de KPIs para la dirección.',
+      },
+      {
+        title: 'Resultado',
+        description:
+          'Los operadores adoptaron la nueva interfaz con mínima capacitación y la dirección obtuvo una vista consolidada de desempeño y tendencias de paradas.',
+      },
+      {
+        title: 'Tecnologías utilizadas',
+        description: 'Ignition, ThingsBoard, MQTT, PostgreSQL, integración con PLC Allen-Bradley, diseño UI responsivo.',
+      },
+      {
+        title: 'Testimonio',
+        description:
+          '“Coordinando equipos en inglés y español, Eduardo mantuvo a todos alineados y entregó una actualización SCADA sólida. Los nuevos dashboards nos dieron la visibilidad que necesitábamos.”',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Dashboards SCADA modernos en múltiples dispositivos',
+    }}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isAfterContent
+    tagline="Diseño eléctrico"
+    title="Paquete de tableros AutoCAD para sistema batch"
+    items={[
+      {
+        title: 'Problema',
+        description:
+          'Un fabricante de procesos en expansión necesitaba planos listos para fabricación y listas de materiales alineadas a los estándares corporativos.',
+      },
+      {
+        title: 'Solución',
+        description:
+          'Produje esquemas AutoCAD, layouts de tableros y listas de cables cubriendo distribución de potencia, I/O PLC y circuitos de seguridad, junto con BOM listas para compras.',
+      },
+      {
+        title: 'Resultado',
+        description:
+          'El taller fabricó sin retrabajos y mantenimiento cuenta ahora con documentación as-built precisa para futuras mejoras.',
+      },
+      {
+        title: 'Tecnologías utilizadas',
+        description: 'AutoCAD Electrical, lineamientos UL 508A, hardware Allen-Bradley, plantillas de documentación.',
+      },
+      {
+        title: 'Testimonio',
+        description:
+          '“Cada entregable de Eduardo está listo para producción. Los nuevos tableros llegaron con planos impecables, protocolos de prueba y capacitación.”',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1580894908361-967195033215?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Diseño de tablero de control en AutoCAD',
+    }}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Hablemos de tu proyecto',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+    ]}
+  >
+    <Fragment slot="title">Lleva tu próxima idea de automatización a producción</Fragment>
+
+    <Fragment slot="subtitle">
+      Diseñemos juntos cómo pasar del concepto a la ejecución con confianza.
+    </Fragment>
   </CallToAction>
 </Layout>
-
-
-

--- a/src/pages/es/pricing.astro
+++ b/src/pages/es/pricing.astro
@@ -1,0 +1,212 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroText from '~/components/widgets/HeroText.astro';
+import Prices from '~/components/widgets/Pricing.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Planes y precios',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    tagline="Precios"
+    title="Planes que acompañan cada etapa"
+    subtitle="Elige el paquete que mejor se ajusta a tus metas de automatización e IIoT."
+  />
+
+  <!-- Pricing Widget ******************* -->
+
+  <Prices
+    title="Nuestros planes"
+    subtitle="Paga solo por lo que necesitas"
+    prices={[
+      {
+        title: 'básico',
+        subtitle: 'Ideal para pruebas de concepto y equipos pequeños',
+        price: 29,
+        period: 'por hora',
+        items: [
+          { description: 'Asesoría remota para proyectos puntuales' },
+          { description: 'Revisión de lógica PLC o diagramas eléctricos' },
+          { description: 'Recomendaciones de arquitectura IIoT' },
+          { description: 'Informe con acciones priorizadas' },
+        ],
+        callToAction: {
+          target: '_blank',
+          text: 'Solicitar',
+          href: '#',
+        },
+      },
+      {
+        title: 'pro',
+        subtitle: 'La opción preferida para modernizar líneas de producción',
+        price: 69,
+        period: 'por hora',
+        items: [
+          { description: 'Desarrollo de lógica PLC y plantillas HMI' },
+          { description: 'Integración MQTT/Sparkplug y dashboards' },
+          { description: 'Documentación y capacitación remota' },
+          { description: 'Soporte post entrega (30 días)' },
+          { description: 'Actualizaciones en inglés y español' },
+        ],
+        callToAction: {
+          target: '_blank',
+          text: 'Solicitar',
+          href: '#',
+        },
+        hasRibbon: true,
+        ribbonTitle: 'popular',
+      },
+      {
+        title: 'enterprise',
+        subtitle: 'Para programas multi-planta y despliegues IIoT escalables',
+        price: 199,
+        period: 'por hora',
+        items: [
+          { description: 'Arquitectura OT/IT completa y gobernanza' },
+          { description: 'Integraciones cloud (AWS, Azure, GCP)' },
+          { description: 'Diseño eléctrico UL 508A y documentación as-built' },
+          { description: 'Soporte extendido y acuerdos SLA personalizados' },
+        ],
+        callToAction: {
+          target: '_blank',
+          text: 'Agendar llamada',
+          href: '#',
+        },
+      },
+    ]}
+  />
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    title="Beneficios incluidos"
+    subtitle="Ventajas de trabajar con mis paquetes de servicios"
+    columns={2}
+    items={[
+      {
+        title: 'Planes escalonados',
+        description: 'Opciones flexibles que se adaptan al alcance de tu proyecto y presupuesto.',
+        icon: 'tabler:stairs',
+      },
+      {
+        title: 'Transparencia total',
+        description: 'Costos claros desde el inicio, sin cargos ocultos ni sorpresas en la facturación.',
+        icon: 'tabler:flip-vertical',
+      },
+      {
+        title: 'Pagos seguros',
+        description: 'Pasarelas protegidas para resguardar tu información financiera.',
+        icon: 'tabler:shield-lock',
+      },
+      {
+        title: 'Acceso inmediato',
+        description: 'Comienzo a trabajar contigo en cuanto se define el alcance y el plan seleccionado.',
+        icon: 'tabler:accessible',
+      },
+      {
+        title: 'Escalamiento sencillo',
+        description: 'Puedes migrar a un plan superior para sumar funcionalidades y soporte adicional.',
+        icon: 'tabler:chevrons-up',
+      },
+      {
+        title: 'Soporte dedicado',
+        description: 'Consultas atendidas por correo, videollamada o chat según el plan contratado.',
+        icon: 'tabler:headset',
+      },
+    ]}
+    classes={{ container: 'max-w-5xl' }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Un proceso guiado, de la idea a la entrega"
+    tagline="proceso simplificado"
+    isReversed
+    items={[
+      {
+        title: 'Paso 1: Selección de plan',
+        description: 'Elegimos juntos el plan que mejor se ajusta a tus objetivos y cronograma.',
+        icon: 'tabler:list-check',
+      },
+      {
+        title: 'Paso 2: Kick-off y planificación',
+        description: 'Definimos alcance, hitos y accesos para iniciar el trabajo con claridad.',
+        icon: 'tabler:timeline-event',
+      },
+      {
+        title: 'Paso 3: Entrega iterativa',
+        description: 'Avances semanales con demos, documentación y ajustes según feedback.',
+        icon: 'tabler:refresh',
+      },
+      {
+        title: 'Paso 4: Cierre y soporte',
+        description: 'Handover completo, capacitación y soporte según lo acordado en el plan.',
+        icon: 'tabler:handshake',
+      },
+    ]}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Resuelve tus dudas antes de elegir un plan"
+    tagline="FAQs"
+    items={[
+      {
+        title: '¿Qué incluye cada plan?',
+        description:
+          'Todos los planes contemplan reuniones de seguimiento, entregables documentados y un repositorio compartido. La diferencia está en el alcance de ingeniería y el nivel de soporte continuo.',
+      },
+      {
+        title: '¿Puedo combinar servicios?',
+        description:
+          'Sí. Podemos iniciar con un plan básico para discovery y luego migrar a Pro o Enterprise para ejecución y soporte extendido.',
+      },
+      {
+        title: '¿Ofreces contratos por proyecto?',
+        description:
+          'Claro. Los planes sirven como referencia; preparo propuestas fijas o por hitos según tu necesidad.',
+      },
+      {
+        title: '¿Cuál es el plazo de entrega típico?',
+        description:
+          'Depende del alcance. Un diagnóstico suele tomar 1-2 semanas; proyectos de implementación van de 4 a 12 semanas.',
+      },
+      {
+        title: '¿Trabajas con clientes internacionales?',
+        description:
+          'Sí. Colaboro con empresas de Norteamérica y Europa, coordinando en inglés o español según el equipo.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Solicitar propuesta',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+      {
+        text: 'Ver portafolio',
+        href: '/es/portfolio',
+      },
+    ]}
+  >
+    <Fragment slot="title">¿Listo para impulsar tu iniciativa?</Fragment>
+    <Fragment slot="subtitle">Agendemos una llamada y definamos el plan ideal para tu proyecto de automatización o IIoT.</Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/privacy.md
+++ b/src/pages/es/privacy.md
@@ -1,0 +1,51 @@
+---
+title: 'Política de privacidad'
+layout: '~/layouts/MarkdownLayout.astro'
+---
+
+# Última actualización: 29 de marzo de 2025
+
+Eduardo Vieira ("yo", "mí", "mi") opera el sitio web eduardovieira.dev (el "Sitio"). Esta página describe las políticas respecto a la recopilación, uso y divulgación de información personal recibida de los usuarios del Sitio.
+
+Tu privacidad es importante para mí. Me comprometo a respetarla con respecto a cualquier información que pueda recopilar en el sitio.
+
+## 1. Recopilación y uso de información
+
+* Formularios de contacto: si utilizas el formulario de contacto del Sitio, recopilaré la información que proporciones (como nombre, correo electrónico y mensaje) únicamente para responder a tu consulta.
+* Analítica: como muchos operadores, puedo utilizar servicios de terceros como Google Analytics que recopilan, monitorean y analizan datos estándar de registro y patrones de comportamiento de los visitantes. Esta información se procesa de forma que no identifica personalmente a nadie y se usa para comprender cómo se utiliza el Sitio y mejorar la experiencia.
+
+## 2. Cookies
+
+Las cookies son archivos con pequeñas cantidades de datos que pueden incluir un identificador anónimo. Se envían a tu navegador desde un sitio web y se almacenan en el disco duro de tu equipo.
+
+El Sitio puede utilizar cookies con fines analíticos según lo descrito. Puedes configurar tu navegador para rechazar todas las cookies o para indicar cuándo se envía una. Sin embargo, si no aceptas cookies, algunas partes del Sitio pueden no funcionar correctamente.
+
+## 3. Seguridad de los datos
+
+Valoro tu confianza al proporcionar información personal, por lo que utilizo medios comercialmente aceptables para protegerla. Aun así, recuerda que ningún método de transmisión por Internet o almacenamiento electrónico es 100% seguro, por lo que no puedo garantizar su seguridad absoluta.
+
+## 4. Conservación de datos
+
+Conservo la información recopilada solo durante el tiempo necesario para brindarte el servicio solicitado o responder tus consultas. Protegeré los datos almacenados dentro de medios comercialmente aceptables para evitar pérdidas, robos o accesos no autorizados.
+
+## 5. Compartición de información
+
+No comparto información de identificación personal de manera pública ni con terceros, salvo que la ley lo requiera.
+
+## 6. Enlaces a otros sitios
+
+El Sitio puede contener enlaces a sitios externos que no opero. No tengo control sobre el contenido ni las prácticas de esos sitios, por lo que no puedo asumir responsabilidad por sus políticas de privacidad.
+
+## 7. Tus derechos
+
+Dependiendo de tu ubicación (por ejemplo, residentes de la UE/EEE bajo el RGPD), puedes tener derechos sobre tus datos personales, incluyendo acceder, corregir, eliminar o restringir su tratamiento. Contáctame si deseas ejercer estos derechos.
+
+## 8. Cambios en esta política de privacidad
+
+Esta Política de Privacidad es efectiva desde el 29 de marzo de 2025 y permanecerá vigente excepto por cambios futuros, que entrarán en vigor inmediatamente después de su publicación en esta página.
+
+Me reservo el derecho de actualizar o modificar esta Política en cualquier momento; te recomendamos revisarla periódicamente. El uso continuado del Sitio después de publicar modificaciones implicará tu aceptación de los cambios.
+
+## 9. Contacto
+
+Si tienes preguntas sobre esta Política de Privacidad, comunícate mediante la información disponible en la [Página de contacto](/es/contact).

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -6,62 +6,194 @@ import Hero from '~/components/widgets/Hero.astro';
 import Testimonials from '~/components/widgets/Testimonials.astro';
 import Layout from '~/layouts/PageLayout.astro';
 
-const metadata = { title: 'Servicios Profesionales | Eduardo Vieira' };
+const metadata = {
+  title: 'Servicios profesionales | Eduardo Vieira',
+};
 ---
 
 <Layout metadata={metadata}>
+  <!-- Hero Widget ******************* -->
+
   <Hero
     tagline="Servicios"
-    title="De la lógica PLC a insights en la nube"
-    subtitle="Soluciones de automatización e IIoT de punta a punta—controladores, HMIs, edge y nube."
+    title="De la lógica PLC a la inteligencia en la nube"
+    subtitle="Entrego soluciones de automatización industrial e IIoT de punta a punta: programo controladores, construyo HMIs, conecto dispositivos edge e integro pipelines de datos seguros hacia la nube."
     actions={[{ variant: 'primary', text: 'Contáctame', href: '/es/contact' }]}
-    image={{ src: '~/assets/images/industrial-automation.jpg', alt: 'Ingeniería de Automatización Industrial' }}
+    image={{
+      src: '~/assets/images/industrial-automation.jpg',
+      alt: 'Ingeniería de automatización industrial',
+    }}
   />
 
+  <!-- Features2 Widget ************** -->
+
   <Features2
-    title="Cómo puedo ayudar"
-    subtitle="Cinco pilares de servicio para tu proyecto de Industria 4.0."
+    title="Cómo puedo ayudarte"
+    subtitle="Cinco pilares de servicio que cubren todo el ciclo de vida de proyectos de manufactura inteligente."
     columns={2}
-    items=[
-      { title: 'Programación PLC & Control', description: 'Siemens, Allen-Bradley, Mitsubishi, CODESYS, ABB.', icon: 'tabler:device-analytics' },
-      { title: 'HMI & SCADA', description: 'Ignition, ThingsBoard, Node-RED, WinCC, PanelView.', icon: 'tabler:layout-dashboard' },
-      { title: 'Web HMI & Dashboards', description: 'Experiencias responsivas seguras.', icon: 'tabler:devices' },
-      { title: 'IIoT & Nube', description: 'MQTT, Sparkplug B, AWS, Azure, GCP.', icon: 'tabler:cloud-computing' },
-      { title: 'Paneles & Diseño Eléctrico', description: 'Planos, layout y BOM.', icon: 'tabler:tool' },
-    ]
+    items={[
+      {
+        title: 'Programación PLC y control industrial',
+        description:
+          'Diseño, optimizo y soluciono lógica de control confiable para máquinas nuevas o retrofits. Tecnologías: Siemens (TIA Portal), Allen-Bradley (Studio 5000), Mitsubishi (GX Works), CODESYS, ABB. Lenguajes: Ladder, Structured Text, FBD.',
+        icon: 'tabler:device-analytics',
+      },
+      {
+        title: 'Desarrollo de sistemas HMI y SCADA',
+        description:
+          'Pantallas intuitivas para operadores y dashboards ejecutivos con KPIs en vivo. Tecnologías: Ignition, ThingsBoard, FUXA, Node-RED, Siemens WinCC, PanelView, Weintek.',
+        icon: 'tabler:layout-dashboard',
+      },
+      {
+        title: 'Web HMI y dashboards remotos',
+        description:
+          'Experiencias responsivas basadas en navegador que entregan datos OT de forma segura en cualquier dispositivo. Tecnologías: Ignition Perspective, Node-RED, ThingsBoard, Grafana, MQTT, APIs REST, VPN e identidad segura.',
+        icon: 'tabler:devices',
+      },
+      {
+        title: 'Integración IIoT y cloud',
+        description:
+          'Pipelines de datos seguros y escalables que llevan información OT a plataformas empresariales. Tecnologías: MQTT (HiveMQ, Mosquitto), Sparkplug B, AWS IoT, Azure IoT, Google Cloud, Python, edge computing industrial con Raspberry Pi y PCs.',
+        icon: 'tabler:cloud-computing',
+      },
+      {
+        title: 'Diseño eléctrico y tableros',
+        description:
+          'Paquetes completos de ingeniería eléctrica con esquemas, selección de componentes, layout y generación de listas de materiales. Tecnologías: AutoCAD, conocimiento UL 508A, normas de seguridad industrial.',
+        icon: 'tabler:tool',
+      },
+    ]}
   />
+
+  <!-- Content Widget **************** -->
 
   <Content
     isReversed
-    items=[
-      { title: 'Auditoría & Requisitos', description: 'Entendemos procesos, cumplimiento y metas.' , icon: 'tabler:clipboard-data' },
-      { title: 'Ingeniería & Implementación', description: 'Lógica PLC, HMI, edge y nube en conjunto.', icon: 'tabler:layout-board' },
-      { title: 'Documentación & Entrega', description: 'Repos, planos, SOPs y capacitación.', icon: 'tabler:clipboard-check' },
-    ]
-    image={{ src: '~/assets/images/automation-benefits.jpg', alt: 'Beneficios de la automatización' }}
+    items={[
+      {
+        title: 'Auditoría y requerimientos',
+        description:
+          'Comenzamos entendiendo tus procesos, requisitos normativos y metas de datos para definir una hoja de ruta clara.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Ingeniería e implementación',
+        description:
+          'Desarrollo lógica PLC, HMIs, gateways edge e integraciones cloud en paralelo, asegurando que cada capa funcione en conjunto.',
+        icon: 'tabler:layout-board',
+      },
+      {
+        title: 'Documentación y entrega',
+        description:
+          'Entrego repositorios de código estructurados, diagramas eléctricos, SOPs y capacitación para que tu equipo opere con confianza.',
+        icon: 'tabler:clipboard-check',
+      },
+    ]}
+    image={{
+      src: '~/assets/images/automation-benefits.jpg',
+      alt: 'Beneficios de la automatización industrial',
+    }}
   >
     <Fragment slot="content">
-      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Un marco probado</h3>
-      <p>Proceso disciplinado: descubrimiento, diseño, comisionamiento, entrenamiento y soporte.</p>
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Un marco probado de proyectos</h3>
+      <p>
+        Cada servicio sigue un proceso disciplinado: iniciamos con el descubrimiento, pasamos por el diseño detallado y finalizamos con la puesta en marcha, capacitación y soporte. Recibes un único socio capaz de liderar todo el viaje OT-IT.
+      </p>
     </Fragment>
   </Content>
 
+  <!-- Content Widget **************** -->
+
+  <Content
+    isAfterContent
+    items={[
+      {
+        title: 'Visibilidad de producción',
+        description: 'Dashboards y alertas en tiempo real mantienen a operaciones por delante de paradas y desvíos de calidad.',
+        icon: 'tabler:eye',
+      },
+      {
+        title: 'Arquitectura escalable',
+        description:
+          'Diseño soluciones listas para crecer; puedes sumar máquinas, sensores o analítica sin reconstruir la base.',
+        icon: 'tabler:topology-star-3',
+      },
+      {
+        title: 'Ciberseguridad y confiabilidad',
+        description:
+          'Defensa en profundidad, pruebas estructuradas y opciones de soporte remoto protegen tu entorno productivo.',
+        icon: 'tabler:shield-lock',
+      },
+      {
+        title: 'Colaboración bilingüe',
+        description:
+          'Español nativo e inglés fluido para coordinar equipos multinacionales sin fricciones.',
+        icon: 'tabler:world',
+      },
+    ]}
+    image={{
+      src: '~/assets/images/industrial-benefits.jpg',
+      alt: 'Beneficios de proyectos industriales',
+    }}
+  >
+    <Fragment slot="content">
+      <h3 class="text-2xl font-bold tracking-tight dark:text-white sm:text-3xl mb-2">Resultados medibles</h3>
+      <p>
+        El objetivo siempre es claro: reducir downtime, mejorar throughput y brindar a los decisores datos confiables. Desde mejoras puntuales hasta despliegues IIoT planta-completa, me enfoco en generar retorno rápido y sostenible.
+      </p>
+    </Fragment>
+  </Content>
+
+  <!-- Testimonials Widget *********** -->
+
   <Testimonials
-    title="Testimonios"
-    subtitle="Resultados reales con fabricantes"
-    testimonials={[{ testimonial: 'De PLC a dashboards en AWS sin interrumpir producción.', name: 'Líder de Ingeniería', job: 'Modernización IIoT' }]}
+    title="Testimonios de clientes"
+    subtitle="Fabricantes que modernizaron su automatización junto a mí"
+    testimonials={[
+      {
+        testimonial: `Eduardo se encargó de todo, desde la programación PLC hasta el despliegue de dashboards. Pasamos de máquinas aisladas a un SCADA unificado en tiempo récord.`,
+        name: 'Senior Controls Engineer',
+        job: 'Proveedor automotriz',
+      },
+      {
+        testimonial: `Nuestros tableros y documentación fueron impecables. El diseño listo para UL ahorró semanas de revisión y el soporte en puesta en marcha fue invaluable.`,
+        name: 'Engineering Manager',
+        job: 'OEM de packaging',
+      },
+      {
+        testimonial: `Conectar nuestra planta a AWS parecía desafiante. Eduardo diseñó la arquitectura MQTT, entrenó al equipo y entregó un pipeline seguro que simplemente funciona.`,
+        name: 'Líder de Transformación Digital',
+        job: 'Fabricante de alimentos y bebidas',
+      },
+    ]}
+    callToAction={{
+      target: '_blank',
+      text: 'Ver mi perfil en Upwork',
+      href: 'https://www.upwork.com/freelancers/~01f21c52fa13e6a195',
+      icon: 'tabler:external-link',
+    }}
   />
 
+  <!-- CallToAction Widget *********** -->
+
   <CallToAction
-    actions=[
-      { variant: 'primary', text: 'Agendar Consulta', href: '/es/contact', icon: 'tabler:mail' },
-      { text: 'Ver Portafolio', href: '/es/portfolio' },
-    ]
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Agenda una consulta',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+      {
+        text: 'Ver portafolio',
+        href: '/es/portfolio',
+      },
+    ]}
   >
-    <Fragment slot="title">¿Listo para modernizar tu planta?</Fragment>
-    <Fragment slot="subtitle">Reduzcamos tiempos muertos y habilitemos decisiones con datos confiables.</Fragment>
+    <Fragment slot="title">¿Listo para modernizar tu fábrica?</Fragment>
+
+    <Fragment slot="subtitle">
+      Conversemos sobre tu hoja de ruta de automatización y definamos el camino más rápido de la lógica PLC a los insights en la nube.
+    </Fragment>
   </CallToAction>
 </Layout>
-
-
-

--- a/src/pages/es/services/control-panel-design.astro
+++ b/src/pages/es/services/control-panel-design.astro
@@ -1,0 +1,188 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroText from '~/components/widgets/HeroText.astro';
+import Features from '~/components/widgets/Features.astro';
+import Content from '~/components/widgets/Content.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Diseño de Tableros y Ingeniería Eléctrica | Eduardo Vieira',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    title="Diseño de tableros y ingeniería eléctrica"
+    subtitle="Paquetes de ingeniería eléctrica completos: desde esquemáticos y selección de componentes hasta documentación lista para UL y soporte de puesta en marcha."
+    tagline="Ingeniería eléctrica"
+  />
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    tagline="Servicios"
+    title="Diseños listos para fabricación y cumplimiento"
+    subtitle="Documentación detallada que mantiene alineados a instaladores, inspectores y equipos de mantenimiento."
+    items={[
+      {
+        title: 'Esquemáticos de tableros',
+        description:
+          'Planos en AutoCAD Electrical con numeración de cables clara, asignación de terminales y circuitos de seguridad que cumplen las mejores prácticas UL 508A.',
+        icon: 'tabler:layout-grid',
+      },
+      {
+        title: 'Selección de componentes',
+        description:
+          'Especifico breakers, contactores, fuentes de poder, hardware PLC, variadores y dispositivos de seguridad acordes al entorno y al desempeño requerido.',
+        icon: 'tabler:tool',
+      },
+      {
+        title: 'Layout de tableros y vistas 3D',
+        description:
+          'Desarrollo layouts de gabinetes, cálculos térmicos y vistas 3D para asegurar mantenibilidad y fabricación eficiente.',
+        icon: 'tabler:ruler-measure',
+      },
+      {
+        title: 'Listas de materiales',
+        description: 'BOM completas con códigos de fabricante, alternativas de compra y consideraciones de costo.',
+        icon: 'tabler:clipboard-list',
+      },
+      {
+        title: 'Normas y cumplimiento',
+        description:
+          'Diseños informados por UL 508A, NFPA 79, estándares IEC y especificaciones del cliente para auditorías e inspecciones.',
+        icon: 'tabler:shield-check',
+      },
+      {
+        title: 'Soporte de puesta en marcha',
+        description:
+          'Actualizaciones as-built, redlines y soporte on-call durante instalación y arranque para mantener el cronograma.',
+        icon: 'tabler:headset',
+      },
+    ]}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isReversed
+    tagline="Flujo de trabajo"
+    title="Ingeniería eléctrica con mirada de manufactura"
+    items={[
+      {
+        title: 'Colaboración de diseño',
+        description:
+          'Coordino con equipos mecánicos, de control y seguridad para capturar requisitos antes de iniciar los planos.',
+      },
+      {
+        title: 'Control documental',
+        description:
+          'Conjuntos de planos versionados, historial de revisiones e índices que simplifican las aprobaciones de stakeholders.',
+      },
+      {
+        title: 'Entrega digital',
+        description:
+          'Proporciono archivos CAD nativos, PDFs y listas de cables exportadas compatibles con talleres de tableros y sistemas ERP.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Esquemáticos de diseño eléctrico',
+    }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Proceso de diseño de tableros"
+    items={[
+      {
+        title: 'Paso 1: <span class="font-medium">Captura de requerimientos</span>',
+        description:
+          'Reúno listas de cargas, conteo de IO, requisitos de seguridad y restricciones ambientales para definir el alcance.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Paso 2: <span class="font-medium">Dibujo y revisión</span>',
+        description:
+          'Desarrollo esquemáticos y layouts, luego reviso con stakeholders para validar espacio, cableado y selección de componentes.',
+        icon: 'tabler:layout-board',
+      },
+      {
+        title: 'Paso 3: <span class="font-medium">Documentación final</span>',
+        description: 'Emito paquetes listos para construcción, BOM y etiquetas de tablero para fabricación.',
+        icon: 'tabler:files',
+      },
+      {
+        title: 'Paso 4: <span class="font-medium">Soporte a fabricación</span>',
+        description:
+          'Brindo aclaraciones, gestiono cambios en campo y actualizaciones as-built durante la instalación y puesta en marcha.',
+        icon: 'tabler:tools',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Fabricación de tableros de control',
+    }}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Detalles sobre servicios de diseño eléctrico y tableros."
+    tagline="FAQs"
+    classes={{ container: 'max-w-6xl' }}
+    items={[
+      {
+        title: '¿Puedes diseñar siguiendo nuestros estándares corporativos?',
+        description:
+          'Sí. Adopto tus títulos, convenciones de capas, etiquetas de dispositivos y requisitos documentales para integrarme a tus flujos.',
+      },
+      {
+        title: '¿Brindas soporte para certificación UL?',
+        description:
+          'Genero documentación lista para UL 508A y colaboro con talleres certificados para agilizar aprobaciones.',
+      },
+      {
+        title: '¿Puedes actualizar planos existentes?',
+        description:
+          'Por supuesto. Reverso tableros existentes, actualizo esquemáticos y creo paquetes digitales limpios para mantenimiento futuro.',
+      },
+      {
+        title: '¿Entregas cómputos de materiales?',
+        description:
+          'Sí. Las BOM detalladas incluyen números de parte, cantidades y proveedores recomendados para agilizar compras.',
+      },
+      {
+        title: '¿Coordinas con los esfuerzos de programación PLC?',
+        description:
+          'Como programador PLC, aseguro que el diseño eléctrico se alinee con la lógica de control, asignación de IO y planes de expansión.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Solicita una propuesta de diseño',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+    ]}
+  >
+    <Fragment slot="title">¿Necesitas un tablero listo para fabricar de inmediato?</Fragment>
+
+    <Fragment slot="subtitle">
+      Comparte tus requisitos y te entregaré un paquete eléctrico completo listo para fabricación y puesta en marcha.
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/services/hmi-scada.astro
+++ b/src/pages/es/services/hmi-scada.astro
@@ -1,0 +1,187 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroText from '~/components/widgets/HeroText.astro';
+import Features from '~/components/widgets/Features.astro';
+import Content from '~/components/widgets/Content.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Desarrollo de sistemas HMI y SCADA | Eduardo Vieira',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    title="Desarrollo de sistemas HMI y SCADA"
+    subtitle="Diseño interfaces amigables para operadores y dashboards ejecutivos que convierten datos en vivo en decisiones accionables para toda tu organización."
+    tagline="Visualización y control"
+  />
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    tagline="Capacidades"
+    title="Visualización que impulsa mejores decisiones"
+    subtitle="HMIs y sistemas SCADA unificados, intuitivos, seguros y conectados a toda tu pila de automatización."
+    items={[
+      {
+        title: 'Diseño centrado en el operador',
+        description:
+          'Layouts responsivos, navegación clara y vistas por rol que reducen el tiempo de capacitación y minimizan errores.',
+        icon: 'tabler:layout-dashboard',
+      },
+      {
+        title: 'Dashboards ejecutivos',
+        description:
+          'KPIs para dirección, seguimiento de OEE y analítica con drill-down para producción, mantenimiento y calidad.',
+        icon: 'tabler:chart-dots-2',
+      },
+      {
+        title: 'Plataformas SCADA',
+        description:
+          'Ignition, ThingsBoard, FUXA, Node-RED, Siemens WinCC, Allen-Bradley PanelView y Weintek EasyBuilder Pro.',
+        icon: 'tabler:device-desktop-analytics',
+      },
+      {
+        title: 'Estrategias de alarmas y eventos',
+        description:
+          'Priorización configurable, flujos de escalamiento e integración con historiadores para mantener equipos proactivos.',
+        icon: 'tabler:alarm',
+      },
+      {
+        title: 'Acceso remoto seguro',
+        description:
+          'Autenticación por roles, VPNs y comunicaciones cifradas que resguardan los datos sin perder visibilidad.',
+        icon: 'tabler:lock',
+      },
+      {
+        title: 'Integración IIoT',
+        description:
+          'Soporte nativo para MQTT, Sparkplug B, APIs REST y bases de datos para conectar datos OT con MES, ERP y analítica en la nube.',
+        icon: 'tabler:arrows-right-left',
+      },
+    ]}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isReversed
+    tagline="Enfoque"
+    title="Interfaces pensadas para planta y dirección"
+    items={[
+      {
+        title: 'Investigación de usuarios y prototipos',
+        description: 'Workshops y wireframes aseguran que la interfaz refleje flujos reales y perfiles de usuario.',
+      },
+      {
+        title: 'Modelado y contextualización de datos',
+        description: 'Estructuro modelos, tags y convenciones de nombres para que la información tenga sentido en todos los sistemas.',
+      },
+      {
+        title: 'Despliegue y capacitación',
+        description:
+          'Implemento HMIs, servidores SCADA y acceso móvil con documentación completa y material de entrenamiento.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581092918056-0c4c3acd3789?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Diseño de dashboard SCADA',
+    }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Ciclo de vida de un proyecto SCADA"
+    items={[
+      {
+        title: 'Paso 1: <span class="font-medium">Descubrimiento de flujos</span>',
+        description:
+          'Identifico procesos críticos, prioridades de alarmas y necesidades de reporte para definir pantallas y navegación.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Paso 2: <span class="font-medium">Diseño y arquitectura</span>',
+        description:
+          'Creo maquetas UI, estructuras de tags, roles de seguridad y diagramas de infraestructura adaptados a tu entorno.',
+        icon: 'tabler:layout-board',
+      },
+      {
+        title: 'Paso 3: <span class="font-medium">Desarrollo y pruebas</span>',
+        description:
+          'Construyo pantallas, configuro alarmas, conecto fuentes de datos y pruebo con datos reales y simulados.',
+        icon: 'tabler:device-analytics',
+      },
+      {
+        title: 'Paso 4: <span class="font-medium">Despliegue y optimización</span>',
+        description: 'Pongo el sistema en marcha, capacito usuarios y ajusto dashboards conforme surgen nuevos requisitos.',
+        icon: 'tabler:rocket',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581092160607-ee22731c9c64?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Proceso de implementación SCADA',
+    }}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Información clave sobre proyectos HMI y SCADA."
+    tagline="FAQs"
+    classes={{ container: 'max-w-6xl' }}
+    items={[
+      {
+        title: '¿Puedes migrar nuestra HMI heredada?',
+        description:
+          'Sí. Migro desde sistemas legacy a Ignition, ThingsBoard o PanelView modernos manteniendo la funcionalidad y mejorando la usabilidad.',
+      },
+      {
+        title: '¿Soportas despliegues multi-planta?',
+        description:
+          'Diseño arquitecturas que soportan múltiples sitios con monitoreo centralizado, plantillas estandarizadas y controles locales.',
+      },
+      {
+        title: '¿Cómo manejas la racionalización de alarmas?',
+        description:
+          'Trabajamos juntos para categorizar alarmas, fijar prioridades y construir rutas de escalamiento alineadas a ISA-18.2.',
+      },
+      {
+        title: '¿Los dashboards se integran con MES o BI?',
+        description:
+          'Sí. Expongo datos vía MQTT, APIs REST, SQL o data lakes para que tus equipos de analítica construyan reportes avanzados.',
+      },
+      {
+        title: '¿Brindas soporte continuo?',
+        description:
+          'Permanezco disponible para mejoras, nuevas pantallas y refrescos de capacitación a medida que la operación evoluciona.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Planifica tu proyecto SCADA',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+    ]}
+  >
+    <Fragment slot="title">¿Necesitas visibilidad clara en tu planta?</Fragment>
+
+    <Fragment slot="subtitle">
+      Diseñemos HMIs y dashboards que empoderen a operadores y ejecutivos con la información que necesitan en tiempo real.
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/services/iiot-cloud.astro
+++ b/src/pages/es/services/iiot-cloud.astro
@@ -1,0 +1,190 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroText from '~/components/widgets/HeroText.astro';
+import Features from '~/components/widgets/Features.astro';
+import Content from '~/components/widgets/Content.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Integración IIoT y Nube | Eduardo Vieira',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    title="Integración IIoT y nube"
+    subtitle="Conecta máquinas, sensores e historiadores a la nube con pipelines de datos seguros y escalables basados en MQTT, Sparkplug B y las principales plataformas cloud."
+    tagline="Del edge a la empresa"
+  />
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    tagline="Soluciones"
+    title="Pipelines de datos industriales confiables"
+    subtitle="Arquitectura e implementación end-to-end que une OT e IT."
+    items={[
+      {
+        title: 'Expertos en MQTT y Sparkplug B',
+        description:
+          'Diseño estructuras de tópicos, namespaces y modelos de payload que hacen que los datos OT sean contextuales y reutilizables.',
+        icon: 'tabler:cloud',
+      },
+      {
+        title: 'Ingeniería de gateways edge',
+        description:
+          'Despliego Raspberry Pi o PCs industriales con Node-RED, Python y servicios contenedorizados para recolección segura.',
+        icon: 'tabler:cpu',
+      },
+      {
+        title: 'Integraciones en la nube',
+        description:
+          'Soluciones con AWS IoT Core, Azure IoT Hub y Google Cloud para almacenamiento, analítica, gemelos digitales y alertas.',
+        icon: 'tabler:cloud-up',
+      },
+      {
+        title: 'Puentes de protocolo',
+        description:
+          'Integraciones Modbus, OPC UA, Ethernet/IP y APIs REST que conectan equipos legacy con aplicaciones modernas.',
+        icon: 'tabler:arrows-right-left',
+      },
+      {
+        title: 'Gobernanza y seguridad de datos',
+        description:
+          'Autenticación, cifrado, gestión de certificados y segmentación de red alineados con buenas prácticas de ciberseguridad OT.',
+        icon: 'tabler:lock',
+      },
+      {
+        title: 'Analítica y visualización',
+        description:
+          'Conecto SCADA, MES, plataformas BI o data lakes para habilitar monitoreo de condición, mantenimiento predictivo y reportes.',
+        icon: 'tabler:device-analytics',
+      },
+    ]}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isReversed
+    tagline="Entregables"
+    title="Un plano para manufactura conectada"
+    items={[
+      {
+        title: 'Estrategia de datos',
+        description:
+          'Identifico señales críticas, frecuencias de muestreo y políticas de retención para que la información sirva a operaciones, mantenimiento y liderazgo.',
+      },
+      {
+        title: 'Aplicaciones edge',
+        description:
+          'Desarrollo servicios livianos que normalizan, almacenan en buffer y aseguran datos OT en el edge antes de transmitirlos.',
+      },
+      {
+        title: 'Workflows en la nube',
+        description:
+          'Creo dashboards, alertas e integraciones que entregan insights accionables a toda la organización.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Pipeline de datos IIoT',
+    }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Hoja de ruta de un proyecto IIoT"
+    items={[
+      {
+        title: 'Paso 1: <span class="font-medium">Evaluación y casos de uso</span>',
+        description:
+          'Analizo infraestructura, preparación de red y objetivos de negocio para priorizar los casos de uso de mayor valor.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Paso 2: <span class="font-medium">Diseño de arquitectura</span>',
+        description:
+          'Defino topología de edge, red y nube incluyendo controles de seguridad, redundancia y estrategia de escalamiento.',
+        icon: 'tabler:topology-star-3',
+      },
+      {
+        title: 'Paso 3: <span class="font-medium">Implementación y pruebas</span>',
+        description:
+          'Configuro gateways, desarrollo modelos de datos, despliego servicios cloud y valido el flujo end-to-end con activos piloto.',
+        icon: 'tabler:bolt',
+      },
+      {
+        title: 'Paso 4: <span class="font-medium">Despliegue y optimización</span>',
+        description:
+          'Escalo a líneas y sitios adicionales, entreno equipos internos y itero sobre analítica conforme emergen nuevos insights.',
+        icon: 'tabler:rocket',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Flujo de trabajo de IoT industrial',
+    }}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Consultas comunes sobre servicios de integración IIoT y nube."
+    tagline="FAQs"
+    classes={{ container: 'max-w-6xl' }}
+    items={[
+      {
+        title: '¿Puedes trabajar con nuestros sistemas SCADA o MES actuales?',
+        description:
+          'Sí. Integro Ignition, ThingsBoard, Wonderware y otras plataformas para publicar datos en la nube o sincronizarlos con sistemas empresariales.',
+      },
+      {
+        title: '¿Cómo aseguras la conectividad remota?',
+        description:
+          'Implemento túneles VPN, autenticación con certificados y payloads MQTT cifrados junto a segmentación de red para proteger los activos OT.',
+      },
+      {
+        title: '¿Entregas documentación para equipos IT y OT?',
+        description:
+          'Cada proyecto incluye diagramas de arquitectura, diccionarios de datos y runbooks adaptados tanto a técnicos OT como a administradores IT.',
+      },
+      {
+        title: '¿Qué pasa si tenemos conectividad inestable?',
+        description:
+          'El buffer en el edge, la lógica store-and-forward y el monitoreo watchdog aseguran la integridad de datos incluso con redes intermitentes.',
+      },
+      {
+        title: '¿Puedes ayudar con analítica una vez que los datos están en la nube?',
+        description:
+          'Por supuesto. Creo dashboards, configuro alertas y colaboro con tu equipo de datos en mantenimiento predictivo y reportes de KPIs.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Conversemos sobre tu hoja de ruta IIoT',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+    ]}
+  >
+    <Fragment slot="title">¿Listo para conectar tus datos OT con la nube?</Fragment>
+
+    <Fragment slot="subtitle">
+      Diseñemos un pipeline seguro y escalable que entregue visibilidad en tiempo real e inteligencia de negocio.
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/services/plc-programming.astro
+++ b/src/pages/es/services/plc-programming.astro
@@ -1,0 +1,190 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroText from '~/components/widgets/HeroText.astro';
+import Features from '~/components/widgets/Features.astro';
+import Content from '~/components/widgets/Content.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Programación PLC y Control Industrial | Eduardo Vieira',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    title="Programación PLC y Control Industrial"
+    subtitle="Lógica robusta y documentada para máquinas nuevas, retrofits y soporte: diseñada para maximizar disponibilidad, seguridad y mantenibilidad."
+    tagline="Experiencia PLC"
+  />
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    tagline="Qué entrego"
+    title="Control confiable para equipos críticos"
+    subtitle="Experiencia multi-plataforma respaldada por fundamentos de ingeniería mecánica y conocimiento profundo de IIoT."
+    items={[
+      {
+        title: 'Programación multi-vendor',
+        description:
+          'Trabajo con Siemens TIA Portal, Allen-Bradley Studio 5000, Mitsubishi GX Works, ABB y CODESYS en Ladder, Structured Text y Function Block Diagram.',
+        icon: 'tabler:cpu',
+      },
+      {
+        title: 'Puesta en marcha de máquinas nuevas',
+        description:
+          'Desde el diseño de IO hasta la FAT final, desarrollo estructuras limpias de lógica, estándares de nombres y diagnósticos que escalan.',
+        icon: 'tabler:settings',
+      },
+      {
+        title: 'Modernización y migraciones',
+        description:
+          'Actualizo hardware legado, migro entre fabricantes o convierto código obsoleto a estándares modernos sin interrumpir producción.',
+        icon: 'tabler:refresh',
+      },
+      {
+        title: 'Seguridad y cumplimiento',
+        description:
+          'Diseño y valido lógica de seguridad, circuitos de paro de emergencia e interlocks alineados con normativas regionales y evaluaciones de riesgo.',
+        icon: 'tabler:shield-check',
+      },
+      {
+        title: 'Optimización de rendimiento',
+        description:
+          'Reduzco tiempos de ciclo, mejoro secuencias e integro feedback de máquina para mantenimiento predictivo y diagnósticos avanzados.',
+        icon: 'tabler:chart-line',
+      },
+      {
+        title: 'Documentación y capacitación',
+        description:
+          'Entrego comentarios estructurados, especificaciones funcionales, referencias de cableado y formación para una transferencia impecable.',
+        icon: 'tabler:notebook',
+      },
+    ]}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isReversed
+    tagline="Entregables"
+    title="Del concepto a la puesta en marcha"
+    items={[
+      {
+        title: 'Diseño de estrategia de control',
+        description:
+          'Especificaciones funcionales, listas de IO y secuencias basadas en requisitos de proceso y seguridad.',
+      },
+      {
+        title: 'Desarrollo de código y simulación',
+        description:
+          'Código modular, simulación y pruebas en banco para facilitar la puesta en marcha en planta.',
+      },
+      {
+        title: 'Integración HMI y SCADA',
+        description:
+          'Intercambio de datos fluido con interfaces de operador, historiadores y sistemas MES para visibilidad total.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Programación y puesta en marcha de PLC',
+    }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Proceso típico de proyectos PLC"
+    items={[
+      {
+        title: 'Paso 1: <span class="font-medium">Requerimientos y estándares</span>',
+        description:
+          'Recolecto documentación de proceso, normas de seguridad y estándares del cliente para definir arquitectura, nomenclatura y criterios de prueba.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Paso 2: <span class="font-medium">Diseño y desarrollo</span>',
+        description:
+          'Construyo lógica estructurada, alarmas y diagnósticos mientras coordino con equipos mecánicos y eléctricos la secuencia.',
+        icon: 'tabler:layout-board',
+      },
+      {
+        title: 'Paso 3: <span class="font-medium">Pruebas y puesta en marcha</span>',
+        description:
+          'Simulaciones, FAT y soporte en sitio para verificar funcionalidad y cumplimiento de seguridad.',
+        icon: 'tabler:device-analytics',
+      },
+      {
+        title: 'Paso 4: <span class="font-medium">Capacitación y soporte</span>',
+        description:
+          'Proporciono formación, guías de troubleshooting y soporte continuo para actualizaciones e integraciones futuras.',
+        icon: 'tabler:headset',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1581092334254-6ab6ac0f17b2?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Flujo de trabajo de automatización industrial',
+    }}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Todo lo que necesitas saber para trabajar conmigo en proyectos PLC."
+    tagline="FAQs"
+    classes={{ container: 'max-w-6xl' }}
+    items={[
+      {
+        title: '¿Pueden trabajar con nuestro código existente?',
+        description:
+          'Sí. Audito y refactorizo lógica heredada con frecuencia, documentando el comportamiento actual antes de implementar mejoras para no perder funcionalidades críticas.',
+      },
+      {
+        title: '¿Ofreces soporte remoto de troubleshooting?',
+        description:
+          'Claro. Con acceso remoto seguro diagnostico y resuelvo incidencias rápidamente. También puedo coordinar visitas en sitio cuando sea necesario.',
+      },
+      {
+        title: '¿Cómo gestionas la versión y documentación?',
+        description:
+          'Mantengo repositorios organizados, registros de cambios y documentación de diseño para que tu equipo sepa qué se implementó y por qué.',
+      },
+      {
+        title: '¿Integra los PLC con SCADA o sistemas en la nube?',
+        description:
+          'Por supuesto. Conecto lógica PLC con Ignition, ThingsBoard, Node-RED y brokers MQTT para habilitar visualización, analítica y control remoto.',
+      },
+      {
+        title: '¿Qué pasa con la validación de seguridad?',
+        description:
+          'Sigo las normas aplicables, preparo listas de verificación y colaboro con tus responsables de seguridad para confirmar el cumplimiento.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Inicia tu proyecto PLC',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+    ]}
+  >
+    <Fragment slot="title">¿Necesitas lógica PLC confiable?</Fragment>
+
+    <Fragment slot="subtitle">
+      Conversemos sobre tu máquina, proceso o retrofit y construyamos una solución de control en la que tu equipo pueda confiar.
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/services/web-hmi.astro
+++ b/src/pages/es/services/web-hmi.astro
@@ -1,0 +1,190 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroText from '~/components/widgets/HeroText.astro';
+import Features from '~/components/widgets/Features.astro';
+import Content from '~/components/widgets/Content.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import FAQs from '~/components/widgets/FAQs.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Web HMI y Dashboards Remotos | Eduardo Vieira',
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- HeroText Widget ******************* -->
+
+  <HeroText
+    title="Web HMI y dashboards remotos"
+    subtitle="Visualizaciones responsivas basadas en navegador que entregan datos OT en vivo de forma segura a cualquier dispositivo—potenciando a operadores, gerentes y equipos remotos."
+    tagline="Visualización conectada"
+  />
+
+  <!-- Features Widget *************** -->
+
+  <Features
+    id="features"
+    tagline="Capacidades"
+    title="Dashboards industriales pensados para cada pantalla"
+    subtitle="Experiencias web modernas y seguras que amplifican el valor de tus inversiones en PLC y SCADA."
+    items={[
+      {
+        title: 'Interfaces responsivas',
+        description:
+          'Diseño HMIs y dashboards que se adaptan a escritorios, tablets y móviles sin sacrificar claridad ni rendimiento.',
+        icon: 'tabler:devices',
+      },
+      {
+        title: 'UX guiada por flujos',
+        description:
+          'Mapeo tareas de operadores y gerencia en navegación intuitiva, KPIs contextuales e interfaces multilingües.',
+        icon: 'tabler:users',
+      },
+      {
+        title: 'Datos y alarmas en tiempo real',
+        description:
+          'Aprovecho MQTT, WebSockets e historiadores para transmitir valores, eventos y notificaciones a usuarios autorizados.',
+        icon: 'tabler:alarm',
+      },
+      {
+        title: 'Acceso remoto seguro',
+        description:
+          'Implemento VPNs, permisos por rol y cifrado TLS para que la visibilidad remota nunca comprometa la seguridad de producción.',
+        icon: 'tabler:lock',
+      },
+      {
+        title: 'Despliegue en edge y nube',
+        description:
+          'Alojo soluciones en PCs industriales, máquinas virtuales o la nube utilizando Docker, Node-RED, Ignition Perspective o ThingsBoard.',
+        icon: 'tabler:cloud-computing',
+      },
+      {
+        title: 'Integraciones de sistema',
+        description:
+          'Conecto PLCs, historiadores, MES y plataformas analíticas mediante MQTT, APIs REST, OPC UA y bases de datos SQL.',
+        icon: 'tabler:arrows-right-left',
+      },
+    ]}
+  />
+
+  <!-- Content Widget ******************* -->
+
+  <Content
+    isReversed
+    tagline="Entregables"
+    title="Dashboards construidos para quienes toman decisiones"
+    items={[
+      {
+        title: 'Diseño UX y visualización',
+        description:
+          'Facilito workshops, desarrollo personas y prototipos para definir layout de pantallas, prioridades de alarmas y contenido multilingüe.',
+      },
+      {
+        title: 'Ingeniería de pipelines de datos',
+        description:
+          'Normalizo tags, contextualizo modelos y aplico lógica store-and-forward para garantizar desempeño confiable.',
+      },
+      {
+        title: 'Playbooks de despliegue',
+        description:
+          'Entrego builds contenedorizados, documentación y transferencia de conocimiento para que tu equipo opere y evolucione la solución.',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Ingeniero revisando dashboards industriales en múltiples pantallas',
+    }}
+  />
+
+  <!-- Steps Widget ****************** -->
+
+  <Steps
+    title="Hoja de ruta de un proyecto Web HMI"
+    items={[
+      {
+        title: 'Paso 1: <span class="font-medium">Descubrimiento y planificación UX</span>',
+        description:
+          'Entrevisto stakeholders, documento flujos y priorizo KPIs para diseñar experiencias que reflejen tareas reales.',
+        icon: 'tabler:clipboard-data',
+      },
+      {
+        title: 'Paso 2: <span class="font-medium">Arquitectura de datos e integraciones</span>',
+        description:
+          'Defino modelos, políticas de seguridad e infraestructura que conectan PLCs, historiadores y sistemas empresariales.',
+        icon: 'tabler:layout-board',
+      },
+      {
+        title: 'Paso 3: <span class="font-medium">Desarrollo y validación</span>',
+        description:
+          'Construyo dashboards, configuro alarmas y ejecuto simulaciones con datos de producción para asegurar desempeño.',
+        icon: 'tabler:device-analytics',
+      },
+      {
+        title: 'Paso 4: <span class="font-medium">Despliegue y habilitación</span>',
+        description:
+          'Habilito acceso seguro, capacito usuarios en español e inglés y establezco planes de soporte para mejora continua.',
+        icon: 'tabler:rocket',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Equipo colaborando en dashboards digitales',
+    }}
+  />
+
+  <!-- FAQs Widget ******************* -->
+
+  <FAQs
+    title="Preguntas frecuentes"
+    subtitle="Respuestas a las dudas más comunes sobre HMIs web y dashboards remotos."
+    tagline="FAQs"
+    classes={{ container: 'max-w-6xl' }}
+    items={[
+      {
+        title: '¿Las HMIs web reemplazan a nuestro SCADA actual?',
+        description:
+          'Pueden complementar o extender tu SCADA existente. A menudo superpongo dashboards web sobre sistemas actuales para mejorar la accesibilidad sin tocar la infraestructura de control.',
+      },
+      {
+        title: '¿Qué tecnologías utilizas para dashboards web?',
+        description:
+          'Ignition Perspective, Node-RED, ThingsBoard, Grafana, front-ends React/TypeScript personalizados e integraciones seguras MQTT o REST—seleccionadas según tus requisitos y estándares de IT.',
+      },
+      {
+        title: '¿Cómo se protege el acceso remoto?',
+        description:
+          'Permisos por rol, VPN o gateways Zero Trust, certificados TLS y trazas de auditoría aseguran que solo personal autorizado interactúe con datos críticos.',
+      },
+      {
+        title: '¿Los dashboards funcionan con conectividad intermitente?',
+        description:
+          'Sí. Implemento buffers, lógica store-and-forward y degradaciones controladas para que los operadores mantengan visibilidad incluso cuando la red cae.',
+      },
+      {
+        title: '¿Nuestro equipo podrá mantener la solución?',
+        description:
+          'Por supuesto. Entrego documentación, sesiones de capacitación en inglés y español y paquetes de soporte opcionales.',
+      },
+    ]}
+  />
+
+  <!-- CallToAction Widget *********** -->
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Diseña una HMI web',
+        href: '/es/contact',
+        icon: 'tabler:mail',
+      },
+    ]}
+  >
+    <Fragment slot="title">¿Listo para llevar tu HMI a la web?</Fragment>
+
+    <Fragment slot="subtitle">
+      Construyamos dashboards seguros y responsivos que den a cada stakeholder visibilidad en tiempo real de la producción.
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/es/terms.md
+++ b/src/pages/es/terms.md
@@ -1,0 +1,48 @@
+---
+title: 'Términos de servicio'
+layout: '~/layouts/MarkdownLayout.astro'
+---
+
+**Última actualización: 29 de marzo de 2025**
+
+Bienvenido al sitio web personal de Eduardo Vieira (eduardovieira.dev). Estos Términos de Servicio ("Términos") regulan el acceso y uso del sitio y su contenido. Te pedimos que leas detenidamente estos Términos antes de utilizar el sitio.
+
+Al acceder o utilizar el sitio aceptas quedar sujeto a estos Términos. Si no estás de acuerdo con alguna parte, no deberías continuar utilizando el sitio.
+
+**1. Uso del sitio**
+
+Este sitio brinda información sobre los servicios profesionales, portafolio y artículos de Eduardo Vieira relacionados con automatización industrial, sistemas embebidos e ingeniería. El contenido tiene fines exclusivamente informativos.
+
+Te comprometes a usar el sitio únicamente con fines lícitos y de forma que no infrinja derechos ni limite o inhiba el uso y disfrute del sitio por parte de terceros.
+
+**2. Propiedad intelectual**
+
+El contenido de este sitio—including texto, gráficos, logotipos, imágenes y publicaciones del blog—pertenece a Eduardo Vieira o a sus proveedores de contenido y está protegido por leyes internacionales de copyright. No puedes reproducir, distribuir, modificar ni crear obras derivadas sin autorización escrita expresa.
+
+**3. Descargos de responsabilidad**
+
+La información del sitio se proporciona "tal cual" sin declaraciones ni garantías, expresas o implícitas. Eduardo Vieira no realiza declaraciones ni garantías sobre la exactitud o integridad de la información disponible.
+
+Aunque se realizan esfuerzos para mantener la información actualizada y correcta, Eduardo Vieira no garantiza su integridad o precisión, ni se compromete a asegurar que el sitio permanezca disponible o que el material se mantenga actualizado.
+
+**4. Limitación de responsabilidad**
+
+Eduardo Vieira no será responsable ante ti (ya sea bajo legislación contractual, extracontractual o de otro tipo) en relación con el contenido o uso de este sitio por:
+
+*   pérdidas directas;
+*   pérdidas indirectas, especiales o consecuentes; o
+*   pérdidas comerciales, pérdida de ingresos, utilidades o ahorros previstos, pérdida de contratos o relaciones comerciales, pérdida de reputación o goodwill, o pérdida o corrupción de información o datos.
+
+Estas limitaciones aplican incluso si Eduardo Vieira ha sido advertido expresamente sobre la posibilidad de tales daños.
+
+**5. Ley aplicable**
+
+Estos Términos se regirán e interpretarán de acuerdo con las leyes de Brasil. Cualquier disputa relacionada con los Términos estará sujeta a la jurisdicción exclusiva de los tribunales brasileños.
+
+**6. Modificaciones a los Términos**
+
+Eduardo Vieira se reserva el derecho de modificar estos Términos en cualquier momento. Notificaremos los cambios publicando la nueva versión en esta página y actualizando la fecha de "Última actualización". El uso continuado del sitio después de cualquier cambio implica la aceptación de los nuevos Términos.
+
+**7. Contacto**
+
+Si tienes preguntas sobre estos Términos, comunícate con Eduardo Vieira mediante la información disponible en la [Página de contacto](/es/contact).

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 import type { AstroComponentFactory } from 'astro/runtime/server/index.js';
 import type { HTMLAttributes, ImageMetadata } from 'astro/types';
+import type { Lang } from '~/i18n/ui';
 
 export interface Post {
   /** A unique ID number that identifies a post. */
@@ -35,6 +36,9 @@ export interface Post {
 
   /**  */
   draft?: boolean;
+
+  /**  */
+  lang?: Lang;
 
   /**  */
   Content?: AstroComponentFactory;


### PR DESCRIPTION
## Summary
- Localized the Spanish SaaS and startup demo home pages with translated hero messaging, feature grids, pricing, FAQs, and blog highlights so `/es/` visitors get fully native sample experiences.
- Added Spanish landing templates for the click-through, lead-generation, pre-launch, product, sales, and subscription funnels to round out the localized marketing set.
- Translated the remaining technical blog catalog into Spanish—including Modbus operations, MQTT architecture, PLC best practices, IIoT rollouts, Raspberry Pi use cases, industry trends, and the ThingsBoard series—so the `/es/blog` feed is complete.

## Testing
- `npm run check:astro` *(fails: existing TypeScript issues in shared header utilities and Portuguese pages)*
- `npm run check:eslint` *(fails: existing unused-variable violations and parse errors in Portuguese pages)*
- `npm run check:prettier` *(fails: repository-wide formatting drift predating this work)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0ab025b483328cddbdbe31f4044d