### PR TITLE
Fix Astro build regressions in translated pages

### DIFF
--- a/src/components/common/Image.astro
+++ b/src/components/common/Image.astro
@@ -41,12 +41,30 @@ const _image = await findImage(props.src);
 
 let image: ImageType | undefined = undefined;
 
-if (
-  typeof _image === 'string' &&
-  (_image.startsWith('http://') || _image.startsWith('https://')) &&
-  isUnpicCompatible(_image)
-) {
-  image = await getImagesOptimized(_image, props, unpicOptimizer);
+if (typeof _image === 'string') {
+  if (_image.startsWith('http://') || _image.startsWith('https://')) {
+    if (isUnpicCompatible(_image)) {
+      image = await getImagesOptimized(_image, props, unpicOptimizer);
+    } else {
+      const excludedKeys = new Set([
+        'src',
+        'widths',
+        'layout',
+        'aspectRatio',
+        'objectPosition',
+        'format',
+        'background',
+      ]);
+
+      const attributes = Object.fromEntries(
+        Object.entries(props).filter(([key]) => !excludedKeys.has(key) && !key.includes(':'))
+      ) as HTMLAttributes<'img'>;
+
+      image = { src: _image, attributes };
+    }
+  } else if (_image) {
+    image = await getImagesOptimized(_image, props, astroAssetsOptimizer);
+  }
 } else if (_image) {
   image = await getImagesOptimized(_image, props, astroAssetsOptimizer);
 }

--- a/src/pages/es/homes/startup.astro
+++ b/src/pages/es/homes/startup.astro
@@ -59,9 +59,7 @@ const metadata = {
 
   <Features2
     title="Quiénes somos"
-    subtitle="Creemos en convertir grandes ideas en experiencias web memorables. Somos desarrolladores apasionados que
-    simplificamos la creación de sitios uniendo la innovación de Astro 5.0 con la flexibilidad de Tailwind CSS. Así tu marca
-    se expresa con identidad propia."
+    subtitle="Creemos en convertir grandes ideas en experiencias web memorables. Somos desarrolladores apasionados que simplificamos la creación de sitios uniendo la innovación de Astro 5.0 con la flexibilidad de Tailwind CSS. Así tu marca se expresa con identidad propia."
   >
     <Fragment slot="bg">
       <div class="absolute inset-0 bg-blue-50 dark:bg-transparent"></div>
@@ -132,8 +130,7 @@ const metadata = {
 
   <Features2
     title="¿Qué ofrecemos?"
-    subtitle="Un catálogo de plantillas para negocios, portafolios, e-commerce, blogs y mucho más, listas para lanzar con
-    tu stack preferido."
+    subtitle="Un catálogo de plantillas para negocios, portafolios, e-commerce, blogs y mucho más, listas para lanzar con tu stack preferido."
     items={[
       {
         title: 'Guías de instalación',

--- a/src/pages/es/pricing.astro
+++ b/src/pages/es/pricing.astro
@@ -150,7 +150,7 @@ const metadata = {
       {
         title: 'Paso 4: Cierre y soporte',
         description: 'Handover completo, capacitación y soporte según lo acordado en el plan.',
-        icon: 'tabler:handshake',
+        icon: 'tabler:heart-handshake',
       },
     ]}
   />

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -30,11 +30,11 @@ const metadata = { title: 'Sobre | Eduardo Vieira' };
     isReversed
     tagline="Trajetória"
     title="De sistemas mecânicos a fábricas conectadas"
-    items=[
+    items={[
       { title: 'Bases mecânicas', description: 'Projeto e programação de máquinas sob medida.' },
       { title: 'Automação', description: 'PLC, SCADA e otimização de controle.' },
       { title: 'Especialização em IIoT', description: 'Pipelines seguros para a nuvem.' },
-    ]
+    ]}
     image={{ src: 'https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=2070&q=80', alt: 'Engenheiro' }}
   >
     <Fragment slot="content">
@@ -47,23 +47,23 @@ const metadata = { title: 'Sobre | Eduardo Vieira' };
     subtitle="O que define minha abordagem"
     columns={3}
     isBeforeContent={true}
-    items=[
+    items={[
       { title: 'Ponte OT & IT', description: 'Tradução entre controle, TI e liderança.', icon: 'tabler:arrows-left-right' },
       { title: 'Propriedade ponta a ponta', description: 'Da lógica PLC aos dashboards em nuvem.', icon: 'tabler:building-factory-2' },
       { title: 'Dados acionáveis', description: 'KPIs e decisões embasadas.', icon: 'tabler:chart-dots-2' },
-    ]
+    ]}
   />
 
   <Features2
     title="Tecnologias"
     tagline="Skills"
     columns={4}
-    items=[
+    items={[
       { title: 'Automação Industrial', description: 'PLC, motion e segurança.' },
       { title: 'SCADA & HMIs', description: 'Interfaces e alarmes.' },
       { title: 'IIoT & Dados', description: 'MQTT, Sparkplug B, AWS/Azure/GCP.' },
       { title: 'Projeto Elétrico', description: 'Esquemas, layout e BOM.' },
-    ]
+    ]}
   />
 
   <Testimonials title="Depoimentos" subtitle="Opiniões de equipes industriais" testimonials={[{ testimonial: 'Excelentes entregas em IIoT e MQTT.', name: 'Cliente de Controles', job: 'Gateway PLC-Nuvem' }]} />

--- a/src/pages/pt/services.astro
+++ b/src/pages/pt/services.astro
@@ -22,22 +22,22 @@ const metadata = { title: 'Serviços Profissionais | Eduardo Vieira' };
     title="Como posso ajudar"
     subtitle="Cinco pilares de serviço para Indústria 4.0."
     columns={2}
-    items=[
+    items={[
       { title: 'Programação PLC & Controle', description: 'Siemens, Allen-Bradley, Mitsubishi, CODESYS, ABB.', icon: 'tabler:device-analytics' },
       { title: 'HMI & SCADA', description: 'Ignition, ThingsBoard, Node-RED, WinCC, PanelView.', icon: 'tabler:layout-dashboard' },
       { title: 'Web HMI & Dashboards', description: 'Experiências responsivas seguras.', icon: 'tabler:devices' },
       { title: 'IIoT & Nuvem', description: 'MQTT, Sparkplug B, AWS, Azure, GCP.', icon: 'tabler:cloud-computing' },
       { title: 'Painéis & Projeto Elétrico', description: 'Esquemas, layout e BOM.', icon: 'tabler:tool' },
-    ]
+    ]}
   />
 
   <Content
     isReversed
-    items=[
+    items={[
       { title: 'Auditoria & Requisitos', description: 'Processos, compliance e metas.', icon: 'tabler:clipboard-data' },
       { title: 'Engenharia & Implementação', description: 'PLC, HMI, edge e nuvem integrados.', icon: 'tabler:layout-board' },
       { title: 'Documentação & Entrega', description: 'Repos, esquemas, SOPs e treinamento.', icon: 'tabler:clipboard-check' },
-    ]
+    ]}
     image={{ src: '~/assets/images/automation-benefits.jpg', alt: 'Benefícios da automação' }}
   >
     <Fragment slot="content">
@@ -53,10 +53,10 @@ const metadata = { title: 'Serviços Profissionais | Eduardo Vieira' };
   />
 
   <CallToAction
-    actions=[
+    actions={[
       { variant: 'primary', text: 'Agendar Consulta', href: '/pt/contact', icon: 'tabler:mail' },
       { text: 'Ver Portfólio', href: '/pt/portfolio' },
-    ]
+    ]}
   >
     <Fragment slot="title">Pronto para modernizar sua planta?</Fragment>
     <Fragment slot="subtitle">Reduza paradas e habilite decisões com dados confiáveis.</Fragment>


### PR DESCRIPTION
## Summary
- fix array prop bindings on Portuguese services and about pages so Astro parses them correctly
- normalize Spanish startup copy and replace an unavailable Tabler icon in the pricing flow
- add a fallback in the shared Image component for remote hosts that cannot be optimized via Unpic

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cbea5bb67083329832a0a4202e2924